### PR TITLE
Makes Hardsuit Helmets Great Again

### DIFF
--- a/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -148,6 +148,7 @@
   name: base hardsuit helmet
   categories: [ HideSpawnMenu ]
   components:
+  - type: BreathMask
   - type: Sprite
     state: icon # default state used by most inheritors
   - type: Clickable


### PR DESCRIPTION
Previously, our dastardly hardsuits had an awfully inconsistent behaviour with gas tanks. Sometimes, you'd be fine connecting your internals without a breath/gas mask of any kind. Other times, you'd don a rather robust and bulky hardsuit and find that . . . you couldn't just connect that to your gas tank, oh no, not this time, buddy. This time you gotta wear a breath mask. 

This is clearly erroneous behaviour since I can't think of any reason, lore or balancewise as to why the hardsuit helms wouldn't all work with internals. So I changed the primoidal ClothingHeadHardsuitBase in _Cresent to actually simply 'have' the 'BreathMask' component. Therefore all its inheriting children SHOULD work with internals, and the day is saved...

Consistency will be had.