### PR TITLE
Oni Melee Overhaul

### DIFF
--- a/Nyanotrasen/Datasets/Names/oni_female.yml
+++ b/Nyanotrasen/Datasets/Names/oni_female.yml
@@ -19,3 +19,7 @@
   - Mizu
   - Shuten #epic references
   - Suika
+  - Yuuga
+  - Kasen
+  - Chiyari
+  - Yuuma

--- a/Nyanotrasen/Datasets/Names/oni_location.yml
+++ b/Nyanotrasen/Datasets/Names/oni_location.yml
@@ -29,3 +29,7 @@
   - Torokiboshi
   - Umiyameboshi
   - Urukiboshi
+  - Ibaraki
+  - Toutetsu
+  - Tenkajin
+  - Hoshiguma

--- a/Nyanotrasen/Datasets/Names/pitbull.yml
+++ b/Nyanotrasen/Datasets/Names/pitbull.yml
@@ -32,3 +32,4 @@
   - Baby
   - Demon
   - Trixie
+  - Childkiller

--- a/Nyanotrasen/Datasets/Names/pitbull.yml
+++ b/Nyanotrasen/Datasets/Names/pitbull.yml
@@ -32,4 +32,3 @@
   - Baby
   - Demon
   - Trixie
-  - Childkiller

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -37,8 +37,8 @@
       fix1:
         shape:
           !type: PhysShapeCircle
-          radius: 0.38
-        density: 195
+          radius: 0.42
+        density: 220
         restitution: 0.0
         mask:
         - MobMask

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -20,7 +20,7 @@
   - type: HumanoidAppearance
     species: Oni
   - type: Sprite
-    scale: 1.1, 1.1
+    scale: 1.2, 1.2
   - type: Oni
     modifiers:
       coefficients:

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -20,10 +20,12 @@
     speechSounds: Baritone
   - type: HumanoidAppearance
     species: Oni
+  - type: Sprite
+    scale: 1.1, 1.1
   - type: Oni
     modifiers:
       coefficients:
-        Blunt: 1.4
+        Blunt: 1.2
         Slash: 1.2
         Piercing: 1.2
         Asphyxiation: 1.2
@@ -31,6 +33,18 @@
     damageModifierSet: Oni
   - type: Body
     prototype: Human
+  - type: Fixtures
+    fixtures: # TODO: This needs a second fixture just for mob collisions.
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.38
+        density: 195
+        restitution: 0.0
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
   - type: Stamina
   - type: NpcFactionMember
     factions:

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -4,16 +4,26 @@
   id: MobOniBase
   abstract: true
   components:
+  - type: MeleeWeapon
+    soundHit:
+      collection: Punch
+    damage:
+      types:
+      Blunt: 25
+  #Oni Get Faster the closer they are to death.
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      60: 1.5
+      80: 2.0
+      99: 4.0
   - type: Speech
     speechSounds: Baritone
   - type: HumanoidAppearance
     species: Oni
-  - type: Sprite
-    scale: 1.2, 1.2
   - type: Oni
     modifiers:
       coefficients:
-        Blunt: 1.2
+        Blunt: 1.4
         Slash: 1.2
         Piercing: 1.2
         Asphyxiation: 1.2
@@ -21,18 +31,6 @@
     damageModifierSet: Oni
   - type: Body
     prototype: Human
-  - type: Fixtures
-    fixtures: # TODO: This needs a second fixture just for mob collisions.
-      fix1:
-        shape:
-          !type:PhysShapeCircle
-          radius: 0.42
-        density: 220
-        restitution: 0.0
-        mask:
-        - MobMask
-        layer:
-        - MobLayer
   - type: Stamina
   - type: NpcFactionMember
     factions:

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -10,14 +10,11 @@
       types:
       Blunt: 25
   #Oni Get Faster the closer they are to death.
-  - type: MovementSpeedModifier
-  baseWalkSpeed: 1.1
-  baseSprintSpeed: 1.3
   - type: SlowOnDamage
     speedModifierThresholds:
-      60: 1.5
-      80: 2.0
-      99: 4.0
+    60: 1.5
+    80: 2.0
+    99: 4.0
   - type: Speech
     speechSounds: Baritone
   - type: HumanoidAppearance
@@ -51,6 +48,9 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
+  - type: MovementSpeedModifier
+  baseWalkSpeed: 1.1
+  baseSprintSpeed: 1.3
 
 - type: entity
   save: false

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -7,6 +7,7 @@
   - type: MeleeWeapon
     soundHit:
       collection: Punch
+    attackRate: 4
     damage:
       types:
       Blunt: 25

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -5,8 +5,6 @@
   abstract: true
   components:
   - type: MeleeWeapon
-    soundHit:
-      collection: Punch
     attackRate: 4
     damage:
       types:

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -37,7 +37,7 @@
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:
         shape:
-          !type:PhysShapeCircle
+          type: PhysShapeCircle
           radius: 0.38
         density: 195
         restitution: 0.0

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -12,6 +12,9 @@
       types:
       Blunt: 25
   #Oni Get Faster the closer they are to death.
+  - type: MovementSpeedModifier
+  baseWalkSpeed: 1.1
+  baseSprintSpeed: 1.3
   - type: SlowOnDamage
     speedModifierThresholds:
       60: 1.5
@@ -38,7 +41,7 @@
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:
         shape:
-          type: PhysShapeCircle
+          !type: PhysShapeCircle
           radius: 0.38
         density: 195
         restitution: 0.0

--- a/Nyanotrasen/Entities/Mobs/Species/oni.yml
+++ b/Nyanotrasen/Entities/Mobs/Species/oni.yml
@@ -5,7 +5,6 @@
   abstract: true
   components:
   - type: MeleeWeapon
-    attackRate: 4
     damage:
       types:
       Blunt: 25


### PR DESCRIPTION
I've been told that Oni are rather weak and a shite pick in a game where most people have guns and have a rather large front and side profile that lends to them being rather easy targets. Especially when they can't actually shoot back due to their genetics. All right, I say. I'll overtune the Melee race into being a decent pick, and so I have. 

To that end I've added following 'abilities' to Oni:

1. Their punches do real good damage and have a real low cooldown. (Firing a gun's still probably faster.)
2. The lower their health gets, the faster they get, until they're zooming all over the place. They're also quite faster than a base human, too. This is so they can actually close the distance between them and their opponents.
3. They're slightly smaller than their old size, but still larger than a human. 

I think these changes'd make Oni a race people'll actually pick rather than simply ignore save for meme rounds where guns are scarce and melee is king. 