### PR TITLE
Additional Syndicate Loadout Options

### DIFF
--- a/_Crescent/Loadouts/LoadoutGroups/Syndicate/ncsp_loadouts.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/Syndicate/ncsp_loadouts.yml
@@ -21,3 +21,11 @@
   - MicroBombImplanter
   - DeathAcidifierImplanter
   - MacroBombImplanter
+
+- type: loadoutGroup
+  id: NCSPMelee
+  name: loadout-group-contractor-utility
+  loadouts:
+  - EnergySword
+  - EnergySwordDouble
+  - EnergyDaggerBox

--- a/_Crescent/Loadouts/LoadoutGroups/Syndicate/ncsp_loadouts.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/Syndicate/ncsp_loadouts.yml
@@ -13,3 +13,11 @@
   - ShipbreakerNCSPClothingBackpackNCSPSAWS
   - ShipbreakerNCSPClothingBackpackNCSPSatchelSAWS
   - ShipbreakerNCSPClothingBackpackNCSPDuffelbagSAWS
+
+- type: loadoutGroup
+  id: NCSPImplants
+  name: loadout-group-contractor-implanter
+  loadouts:
+  - MicroBombImplanter
+  - DeathAcidifierImplanter
+  - MacroBombImplanter

--- a/_Crescent/Loadouts/LoadoutGroups/Syndicate/syndicate_implants.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/Syndicate/syndicate_implants.yml
@@ -1,0 +1,19 @@
+- type: loadout
+  id: MicroBombImplanter
+  equipment: MicroBombImplanter
+  price: 3000
+
+- type: loadout
+  id: MacroBombImplanter
+  equipment: MacroBombImplanter
+  price: 5000
+
+- type: loadout
+  id: DeathAcidifierImplanter
+  equipment: DeathAcidifierImplanter
+  price: 1000
+
+- type: loadout
+  id: FreedomImplanter
+  equipment: FreedomImplanter
+  price: 2000

--- a/_Crescent/Loadouts/LoadoutGroups/Syndicate/syndicate_weapons
+++ b/_Crescent/Loadouts/LoadoutGroups/Syndicate/syndicate_weapons
@@ -2,3 +2,13 @@
   id: EnergySword
   equipment: EnergySword
   price: 1500
+
+- type: loadout
+  id: EnergySwordDouble
+  equipment: EnergySwordDouble
+  price: 2500
+
+- type: loadout
+  id: EnergyDaggerBox
+  equipment: EnergyDaggerBox
+  price: 800

--- a/_Crescent/Loadouts/LoadoutGroups/Syndicate/syndicate_weapons
+++ b/_Crescent/Loadouts/LoadoutGroups/Syndicate/syndicate_weapons
@@ -1,0 +1,4 @@
+- type: loadout
+  id: EnergySword
+  equipment: EnergySword
+  price: 1500

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -83,6 +83,8 @@
   groups:
   - ContractorTrinkets
   - NCSPBackpacks
+  - NCSPImplants
+  - NCSPMelee
 
 - type: roleLoadout
   id: JobTechnicianNCSP


### PR DESCRIPTION
The items are there, and they're syndicate-aligned. I think they should be able to pick these possibly-suboptimal pieces of kit since they're syndie classics.

What's new:
New Loadout Items for Privateers:
- Eswords, Edaggers, All the (Relevant) Syndicate Implants.

Notably absent is the addition of anything gun-related since they already get guns. 
I might see about adding a few of the syndicate espionage items as trinkets later, as well. 