### PR TITLE
Factions with R&D Understand their Own Technologies

### DIFF
--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -160,9 +160,6 @@
     - ImperialHardsuit
     - ImperialClothes #They're fucking clothes. Why the fuck do you have to research this in the first place?
     - ImperialLightArms
-    - FightersImp
-    - ImperialAvionics
-    - ImperialShuttleArmaments
     - ImperialLongarms
     - ImperialArmor
     - ImperialLaserguns

--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -231,6 +231,7 @@
     - Arsenal
     - Experimental
     - CivilianServices
+    - Precursor #Independent Conspiracy Theorists...
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver

--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -89,14 +89,9 @@
     unlockedTechnologies:
     - CommieClothes
     - CommieArmor
-    - Fighters
     - CommieHeavyArmor
     - CommieLightArms
     - CommieHeavyArms
-    - CommieAvionics
-    - CommieShuttleguns
-    - CommieShuttlegunsMissile
-    - CommieShuttlegunsUltraheavy
 
   - type: ApcPowerReceiver
     powerLoad: 200

--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -16,6 +16,15 @@
     supportedDisciplines:
     - Pirate
     - Arsenal
+    unlockedTechnologies:
+    - SyndicateHardsuit
+    - Sinn #Got to do it for Bo
+    - SyndicateClothes
+    - SyndicateSmallArms
+    - SyndicateAviation
+    - SyndicateShuttleArmaments
+    - SyndicateLongArms
+    - SyndicateEwar
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver

--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -229,7 +229,6 @@
     - Arsenal
     - Experimental
     - CivilianServices
-    - Precursor #Independent Conspiracy Theorists...
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver

--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -18,11 +18,8 @@
     - Arsenal
     unlockedTechnologies:
     - SyndicateHardsuit
-    - Sinn #Got to do it for Bo
     - SyndicateClothes
     - SyndicateSmallArms
-    - SyndicateAviation
-    - SyndicateShuttleArmaments
     - SyndicateLongArms
     - SyndicateEwar
   - type: ApcPowerReceiver

--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -80,6 +80,17 @@
     - Industrial
     - CivilianServices
     - Communard
+    unlockedTechnologies:
+    - CommieClothes
+    - CommieArmor
+    - CommieHeavyArmor
+    - CommieLightArms
+    - CommieHeavyArms
+    - CommieAvionics
+    - CommieShuttleguns
+    - CommieShuttlegunsMissile
+    - CommieShuttlegunsUltraheavy
+    
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver

--- a/_Crescent/Entities/Structures/research.yml
+++ b/_Crescent/Entities/Structures/research.yml
@@ -83,6 +83,7 @@
     unlockedTechnologies:
     - CommieClothes
     - CommieArmor
+    - Fighters
     - CommieHeavyArmor
     - CommieLightArms
     - CommieHeavyArms
@@ -90,7 +91,7 @@
     - CommieShuttleguns
     - CommieShuttlegunsMissile
     - CommieShuttlegunsUltraheavy
-    
+
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver
@@ -154,6 +155,17 @@
     supportedDisciplines:
     - Imperial
     - Arsenal
+    unlockedTechnologies:
+    - ImperialHardsuit
+    - ImperialClothes #They're fucking clothes. Why the fuck do you have to research this in the first place?
+    - ImperialLightArms
+    - FightersImp
+    - ImperialAvionics
+    - ImperialShuttleArmaments
+    - ImperialLongarms
+    - ImperialArmor
+    - ImperialLaserguns
+    - ImperialSword
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: ExtensionCableReceiver


### PR DESCRIPTION
As it stands, there's no reason for why they shouldn't already be capable of doing so. By all means, the items produced by faction research are mass produced and standard kit for members of that very faction. It makes no logical sense that DSM, NCWL, or Syndicates wouldn't know how to produce... their own uniforms - cloth uniforms. It also follows that their armour and firearms would be true and tested designs easily mass-producable by the factions in question, as the firearms in question tend to be based around designs possible in the 21st century... and faction hardsuits are clearly standard-issue equipment and not expensive artisanal suits designed for an elite few. 

To that end I've basically added everything prefixed with 'Imperial' 'Communard', or 'Syndicate' to their respective research servers' databases. The only things I've been apprehensive about are ship-related technologies, as I believe it's been mentioned in the past that ships are actually incredibly rare and poorly understood technology in Tajpan. 

Consider this a lore + gameplay fix. 