### PR TITLE
New Antiquarian Onionslop

### DIFF
--- a/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
+++ b/Entities/Objects/Devices/Syndicate_Gadgets/guardian_activators.yml
@@ -10,6 +10,8 @@
     state: combat_hypo
   - type: GuardianCreator
     guardianProto: MobHoloparasiteGuardian
+  - type: StaticPrice
+    price: 4166
 
 - type: entity
   name: magical lamp

--- a/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Entities/Objects/Devices/chameleon_projector.yml
@@ -20,6 +20,8 @@
       - Pda # PDAs currently make you invisible /!\
     polymorph:
       entity: ChameleonDisguise
+  - type: StaticPrice
+    price: 6000
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Entities/Objects/Devices/encryption_keys.yml
+++ b/Entities/Objects/Devices/encryption_keys.yml
@@ -230,6 +230,8 @@
     - state: crypt_red
     - state: synd_label
   - type: Contraband #frontier
+  - type: StaticPrice
+    price: 15000
 
 - type: entity
   parent: EncryptionKey

--- a/Entities/Objects/Misc/implanters.yml
+++ b/Entities/Objects/Misc/implanters.yml
@@ -245,6 +245,8 @@
     - type: Implanter
       implant: MacroBombImplant
     - type: Contraband #frontier
+    - type: StaticPrice
+      price: 10000
 
 - type: entity
   id: DeathRattleImplanter
@@ -263,3 +265,5 @@
   - type: Implanter
     implant: DeathAcidifierImplant
   - type: Contraband #frontier
+  - type: StaticPrice
+    price: 250

--- a/Entities/Objects/Misc/implanters.yml
+++ b/Entities/Objects/Misc/implanters.yml
@@ -179,6 +179,8 @@
     - type: Implanter
       implant: FreedomImplant
     - type: Contraband #frontier
+    - type: StaticPrice
+      price: 1666
 
 - type: entity
   id: UplinkImplanter

--- a/Entities/Objects/Misc/implanters.yml
+++ b/Entities/Objects/Misc/implanters.yml
@@ -199,6 +199,8 @@
     - type: Implanter
       implant: EmpImplant
     - type: Contraband #frontier
+    - type: StaticPrice
+      price: 1666
 
 - type: entity
   id: ScramImplanter

--- a/Entities/Objects/Misc/implanters.yml
+++ b/Entities/Objects/Misc/implanters.yml
@@ -210,6 +210,8 @@
     - type: Implanter
       implant: ScramImplant
     - type: Contraband #frontier
+    - type: StaticPrice
+      price: 2500
 
 - type: entity
   id: DnaScramblerImplanter

--- a/Entities/Objects/Misc/implanters.yml
+++ b/Entities/Objects/Misc/implanters.yml
@@ -221,6 +221,8 @@
     - type: Implanter
       implant: DnaScramblerImplant
     - type: Contraband #frontier
+    - type: StaticPrice
+      price: 5000
 
 #Nuclear Operative/Special implanters
 

--- a/Entities/Objects/Misc/implanters.yml
+++ b/Entities/Objects/Misc/implanters.yml
@@ -234,6 +234,8 @@
     - type: Implanter
       implant: MicroBombImplant
     - type: Contraband #frontier
+    - type: StaticPrice
+      price: 3333
 
 - type: entity
   id: MacroBombImplanter

--- a/Entities/Objects/Misc/implanters.yml
+++ b/Entities/Objects/Misc/implanters.yml
@@ -168,7 +168,7 @@
     - type: Implanter
       implant: StorageImplant
     - type: StaticPrice
-      price: 500
+      price: 8333
     - type: Contraband #frontier
 
 - type: entity

--- a/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Entities/Objects/Specific/Medical/hypospray.yml
@@ -433,7 +433,7 @@
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta
-    price: 75
+    price: 5000
   - type: Contraband #frontier
 
 - type: entity

--- a/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -82,7 +82,7 @@
   - type: IgnitionSource
     temperature: 700
   - type: StaticPrice
-    price: 5000
+    price: 3333
 
 - type: entity
   name: pen

--- a/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -81,6 +81,8 @@
     enabled: false
   - type: IgnitionSource
     temperature: 700
+  - type: StaticPrice
+    price: 5000
 
 - type: entity
   name: pen
@@ -160,6 +162,8 @@
   - type: DisarmMalus
     malus: 0
   - type: Contraband #frontier
+  - type: StaticPrice
+    price: 1500
 
 - type: entity
   parent: BaseItem
@@ -287,3 +291,5 @@
       - state: inhand-right-blade
         shader: unshaded
   - type: Contraband #frontier
+  - type: StaticPrice
+    price: 6666

--- a/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
@@ -25,3 +25,14 @@
     PipeBomb: 5
     EmpGrenade: 5
     OnionMachineRestock: 15
+    StorageImplanter: 2
+    FreedomImplanter: 10
+    EmpImplanter: 15 #Disposable
+    ScramImplanter: 2
+    DnaScramblerImplanter: 2
+    MacroBombImplanter: 2
+    MicroBombImplanter: 5
+    DeathAcidifierImplant: 30
+    EnergySword: 5
+    EnergyDagger: 5
+    EnergySwordDouble: 2

--- a/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
@@ -37,3 +37,4 @@
     EnergyDagger: 5
     EnergySwordDouble: 2
     HoloparasiteInjector: 5
+    ChameleonProjector: 4

--- a/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
@@ -33,9 +33,6 @@
     MacroBombImplanter: 2
     MicroBombImplanter: 5
     DeathAcidifierImplant: 30
-    EnergySword: 5
-    EnergyDagger: 5
-    EnergySwordDouble: 2
     HoloparasiteInjector: 5
     ChameleonProjector: 4
     Hypopen: 5

--- a/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
@@ -39,3 +39,4 @@
     HoloparasiteInjector: 5
     ChameleonProjector: 4
     Hypopen: 5
+    EncryptionKeySyndie: 4

--- a/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
@@ -38,3 +38,4 @@
     EnergySwordDouble: 2
     HoloparasiteInjector: 5
     ChameleonProjector: 4
+    Hypopen: 5

--- a/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
@@ -36,3 +36,4 @@
     EnergySword: 5
     EnergyDagger: 5
     EnergySwordDouble: 2
+    HoloparasiteInjector: 5

--- a/_Crescent/Entities/Structures/vending_machines.yml
+++ b/_Crescent/Entities/Structures/vending_machines.yml
@@ -151,7 +151,7 @@
   parent: [BaseStructureUnanchorable, VendingMachineWallmount]
   id: OnionAntiquarian
   name: ONION wallconsole
-  description: A wall-mounted computer with a delivery chute to order goods from.
+  description: A wall-mounted computer which delivers its gifts through a chute which reeks of waste.
   components:
   - type: VendingMachine
     pack: OnionInventory


### PR DESCRIPTION
I've added the following items in the following proportions to the Antiquarian's onion.
This is meant to incentivize meeting with the antiquarian and exchanging currency and valuable goods. 

   ``` StorageImplanter: 2
    FreedomImplanter: 10
    EmpImplanter: 15 
    ScramImplanter: 2
    DnaScramblerImplanter: 2
    MacroBombImplanter: 2
    MicroBombImplanter: 5
    DeathAcidifierImplant: 30
    EnergySword: 5
    EnergyDagger: 5
    EnergySwordDouble: 2
    HoloparasiteInjector: 5
    ChameleonProjector: 4
    Hypopen: 5
    EncryptionKeySyndie: 4```

If the prices seem low, they aren't. The onion multiplies item prices by three, so just triple all the numbers in your head. 