### PR TITLE
Grenade Belts/Webbings No Longer Susceptible to Chain Reactions

### DIFF
--- a/Entities/Clothing/Belt/belts.yml
+++ b/Entities/Clothing/Belt/belts.yml
@@ -505,6 +505,8 @@
           - SmokeOnTrigger
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
+  - type: ExplosionResistance
+      damageCoefficient: 0.1
 
 - type: entity
   parent: [ClothingBeltBase, ClothingSlotBase]

--- a/Entities/Clothing/Belt/belts.yml
+++ b/Entities/Clothing/Belt/belts.yml
@@ -620,6 +620,8 @@
     sprite: Clothing/Belt/securitywebbing.rsi
   - type: Clothing
     sprite: Clothing/Belt/securitywebbing.rsi
+  - type: ExplosionResistance
+    damageCoefficient: 0.1
 
 - type: entity
   parent: ClothingBeltStorageBase

--- a/Entities/Clothing/Belt/belts.yml
+++ b/Entities/Clothing/Belt/belts.yml
@@ -506,7 +506,7 @@
     sprite: Clothing/Belt/belt_overlay.rsi
   - type: Appearance
   - type: ExplosionResistance
-      damageCoefficient: 0.1
+      damageCoefficient: 0.5
 
 - type: entity
   parent: [ClothingBeltBase, ClothingSlotBase]
@@ -623,7 +623,7 @@
   - type: Clothing
     sprite: Clothing/Belt/securitywebbing.rsi
   - type: ExplosionResistance
-    damageCoefficient: 0.1
+    damageCoefficient: 0.5
 
 - type: entity
   parent: ClothingBeltStorageBase


### PR DESCRIPTION
Your precious grenades won't blow up if they're inside grenade webbings/belts or security belts anymore.

Downsides: You can't troll by suicide bombing with these unless you move your grenades to your non-grenade safe backpacks first. 