### PR TITLE
Preliminary Outline for Pacification Chips Created for the Express Purpose of Slavery

### DIFF
--- a/Traits/disabilities.yml
+++ b/Traits/disabilities.yml
@@ -24,6 +24,8 @@
   description: trait-pacifist-desc
   components:
     - type: Pacified
+      disallowDisarm: true
+      disallowAllCombat: true
 
 - type: trait
   id: Paracusia

--- a/_Crescent/Entities/Objects/Misc/implanters.yml
+++ b/_Crescent/Entities/Objects/Misc/implanters.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: SoulbreakerImplanter
+  name: soulbreaker chip implanter
+  parent: BaseImplantOnlyImplanter
+  components:
+    - type: Implanter
+      implant: SoulbreakerImplant

--- a/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
+++ b/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
@@ -7,9 +7,6 @@
   components:
     - type: SubdermalImplant
       permanent: true
-    - type: Pacified
-      DisallowDisarm: true
-      DisallowAllCombat: true
     - type: Tag
        - SubdermalImplant
        - HideContextMenu

--- a/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
+++ b/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
@@ -7,7 +7,4 @@
   components:
     - type: SubdermalImplant
       permanent: true
-    - type: Tag
-       - SubdermalImplant
-       - HideContextMenu
-       - Pacified #Someone needs to implement a SoulbreakerComponent and Soulbreaker system to check for this.
+#    - type: SoulbreakerImplant Uncomment this when the component actually exists.

--- a/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
+++ b/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,12 +1,16 @@
-#Soulbreaker Implants - SCORCHING
+#Soulbreaker Implants - SCORCHAH
 - type: entity
   parent: BaseSubdermalImplant
-  id: MedicalTrackingImplant
-  name: medical tracking implant
-  description: This implant has a tracking device monitor for the Interdyne radio channel.
-  categories: [ HideSpawnMenu ]
+  id: SoulbreakerImplant
+  name: soulbreaker implant
+  description: But gradually slavery became an accepted norm, Soulbreakers and other slavery implementations generously supplying the market with new hands.
   components:
     - type: SubdermalImplant
+      permanent: true
     - type: Pacified
       DisallowDisarm: true
       DisallowAllCombat: true
+    - type: Tag
+       - SubdermalImplant
+       - HideContextMenu
+       - Pacified #Someone needs to implement a SoulbreakerComponent and Soulbreaker system to check for this.

--- a/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
+++ b/_Crescent/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,12 @@
+#Soulbreaker Implants - SCORCHING
+- type: entity
+  parent: BaseSubdermalImplant
+  id: MedicalTrackingImplant
+  name: medical tracking implant
+  description: This implant has a tracking device monitor for the Interdyne radio channel.
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: SubdermalImplant
+    - type: Pacified
+      DisallowDisarm: true
+      DisallowAllCombat: true

--- a/tags.yml
+++ b/tags.yml
@@ -1359,3 +1359,5 @@
 - type: Tag # Frontier
   id: WeaponMelee # Frontier
 
+- type: Tag
+  id: Pacified # Hullrot 1.0


### PR DESCRIPTION
This PR adds some skeletal YML for the creation of slavery chips, which I have been informed is something that would be desirable to have. 

However, actually implementing any logic for implants as simple as these goes beyond the scope of .yml and into that of C#, nonetheless, I have an outline of the actual logic in the hypothetical SoulbreakerSystem.cs

```C#
    private void OnInsert(EntityUid uid, SoulbreakerImplantComponent component, ImplantImplantedEvent args)
    {
    //Turns someone into a pacifist if they aren't already.
        if (!args.Implanted.HasValue)
            return;
        var soulbroken = EnsureComp<PacifiedComponent>(args.Implanted.Value);
        Dirty(args.Implanted.Value, soulbroken);
    }  
```
    
    SoulbreakerImplantComponent can be left empty, but does have to exist if we want this to be functional.