### PR TITLE
Only the Antiquarian Can Access the Onion

### DIFF
--- a/_Crescent/Entities/Structures/vending_machines.yml
+++ b/_Crescent/Entities/Structures/vending_machines.yml
@@ -175,6 +175,8 @@
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: MarketModifier
     mod: 3
+  - type: AccessReader
+    access: [["Antiquarian"]]
 
 - type: entity
   parent: [BaseStructureUnanchorable, VendingMachine]


### PR DESCRIPTION
Does what the title says. 
In lieu of a bespoke skill or stat system the only way members of the same species can differentiate themselves is purely through non-mechanical means and their ID's access level. 

This makes the antiquarian, an independent party without any real faction affiliation into someone whose whereabouts will at the very least be something people care about. So this increases player to player roleplay because they'll have to actually talk to the antiquarian or find his ass. 