### PR TITLE
Suit Sensors Maximized

### DIFF
--- a/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -49,6 +49,9 @@
   id: ClothingUniformBase
   components:
   - type: SuitSensor
+    randomMode: false
+    mode: SensorCords
+    controlsLocked: true
   - type: DeviceNetwork
     deviceNetId: Wireless
     transmitFrequencyId: SuitSensor

--- a/_Crescent/Device/devicenet_frequencies.yml
+++ b/_Crescent/Device/devicenet_frequencies.yml
@@ -1,0 +1,24 @@
+- type: deviceFrequency
+  id: SuitSensorDSM
+  name: device-frequency-prototype-name-DSM-suit-sensors
+  frequency: 14
+
+- type: deviceFrequency
+  id: SuitSensorNCWL
+  name: device-frequency-prototype-name-NCWL-suit-sensors
+  frequency: 8888
+
+- type: deviceFrequency
+  id: SuitSensorTSP
+  name: device-frequency-prototype-name-TSP-suit-sensors
+  frequency: 525
+
+- type: deviceFrequency
+  id: SuitSensorSyndicate
+  name: device-frequency-prototype-name-syndicate-suit-sensors
+  frequency: 88
+
+- type: deviceFrequency
+  id: SuitSensorSRM
+  name: device-frequency-prototype-name-SRM-suit-sensors
+  frequency: 717


### PR DESCRIPTION
This PR maximizes every jumpsuit's suit sensors and locks them at that setting unless they explicitly differ in any way. 
I imagine that this would be a boon to the Trauma Team and really just a sane default for anyone at risk of dying out in space. 