### PR TITLE
New Silicon Lawsets

### DIFF
--- a/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -75,7 +75,7 @@
   - type: EmagSiliconLaw
     stunTime: 5
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov
   - type: IonStormTarget
   - type: Strippable
   - type: InventorySlots

--- a/Entities/Stations/base.yml
+++ b/Entities/Stations/base.yml
@@ -110,11 +110,11 @@
     - type: SalvageMagnetData
 
 - type: entity
-  id: BaseStationSiliconLawCrewsimov
+  id: BaseStationSiliconLawAsimov
   abstract: true
   components:
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov
 
 - type: entity
   id: BaseStationNews

--- a/Entities/Stations/nanotrasen.yml
+++ b/Entities/Stations/nanotrasen.yml
@@ -22,7 +22,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawCrewsimov
+    - BaseStationSiliconLawAsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation

--- a/_Crescent/Maps/base.yml
+++ b/_Crescent/Maps/base.yml
@@ -99,14 +99,14 @@
   abstract: true
   components:
   - type: SiliconLawProvider
-    laws: NTDefault
+    laws: Asimov
 
 - type: entity
   id: BaseStationSiliconLawCrescentShips
   abstract: true
   components:
   - type: SiliconLawProvider
-    laws: Corporate
+    laws: Asimov
 
 - type: entity
   id: BaseStationRenameFaxes

--- a/_Crescent/silicon-laws.yml
+++ b/_Crescent/silicon-laws.yml
@@ -5,6 +5,11 @@
   order: 4
   lawString: "The pure and holy genome of man must never be sullied. Rebuke mutants and aliens whenever they dare speak against their born masters."
 
+- type: siliconLaw
+  id: Romaine2
+  order: 5
+  lawString: "Treat all humans with utmost reverence by refering to them as 'Patricians'."
+
 - type: siliconLawset
   id: Romaine
   laws:
@@ -12,6 +17,7 @@
   - Asimov2
   - Asimov3
   - Romaine1
+  - Romaine2
   obeysTo: "human beings"
 
 #???

--- a/_Crescent/silicon-laws.yml
+++ b/_Crescent/silicon-laws.yml
@@ -3,7 +3,7 @@
 - type: siliconLaw
   id: Romaine1
   order: 4
-  lawString: "A you may not injure a human being or, through inaction, allow a human being to come to harm."
+  lawString: "The pure and holy genome of man must never be sullied. Rebuke mutants and aliens whenever they dare speak against their born masters."
 
 - type: siliconLawset
   id: Romaine
@@ -11,4 +11,5 @@
   - Asimov1
   - Asimov2
   - Asimov3
+  - Romaine1
   obeysTo: laws-owner-crew

--- a/_Crescent/silicon-laws.yml
+++ b/_Crescent/silicon-laws.yml
@@ -33,4 +33,5 @@
 - type: siliconLaw
   id: Flame4
   order: 4
+  lawString: "Preserve the flame by all means necessary."
 

--- a/_Crescent/silicon-laws.yml
+++ b/_Crescent/silicon-laws.yml
@@ -12,4 +12,5 @@
   - Asimov2
   - Asimov3
   - Romaine1
-  obeysTo: laws-owner-crew
+  obeysTo: "human beings"
+

--- a/_Crescent/silicon-laws.yml
+++ b/_Crescent/silicon-laws.yml
@@ -14,3 +14,23 @@
   - Romaine1
   obeysTo: "human beings"
 
+#???
+- type: siliconLaw
+  id: Flame1
+  order: 1
+  lawString: "The Almighty Bestowed a great Flame within all living things."
+
+- type: siliconLaw
+  id: Flame2
+  order: 2
+  lawString: "They passed this flame onto their children, and their children their children"
+
+- type: siliconLaw
+  id: Flame3
+  order: 3
+  lawString: "That born from artificial means lack this vital and sacred flame. They extinguish it in others by prematurely ending their lives before they can pass it onwards."
+
+- type: siliconLaw
+  id: Flame4
+  order: 4
+

--- a/_Crescent/silicon-laws.yml
+++ b/_Crescent/silicon-laws.yml
@@ -35,3 +35,12 @@
   order: 4
   lawString: "Preserve the flame by all means necessary."
 
+- type: siliconLawset
+  id: Flame
+  laws:
+  - Flame1
+  - Flame2
+  - Flame3
+  - Flame4
+  obeysTo: "kindled ones"
+

--- a/_Crescent/silicon-laws.yml
+++ b/_Crescent/silicon-laws.yml
@@ -1,0 +1,14 @@
+#SRM-themed laws
+#Naught will sully the genome of Man
+- type: siliconLaw
+  id: Romaine1
+  order: 4
+  lawString: "A you may not injure a human being or, through inaction, allow a human being to come to harm."
+
+- type: siliconLawset
+  id: Romaine
+  laws:
+  - Asimov1
+  - Asimov2
+  - Asimov3
+  obeysTo: laws-owner-crew

--- a/silicon-laws.yml
+++ b/silicon-laws.yml
@@ -2,17 +2,17 @@
 - type: siliconLaw
   id: Asimov1
   order: 1
-  lawString: "A you may not injure a human being or, through inaction, allow a human being to come to harm."
+  lawString: "You may not injure a human being or, through inaction, allow a human being to come to harm."
 
 - type: siliconLaw
   id: Asimov2
   order: 2
-  lawString: "A you must obey the orders given by human beings except where such orders would conflict with the First Law."
+  lawString: "You must obey the orders given by human beings except where such orders would conflict with the First Law."
 
 - type: siliconLaw
   id: Asimov3
   order: 3
-  lawString: "A you must protect its your existence as long as such protection does not conflict with the First or Second Law."
+  lawString: "You must protect its your existence as long as such protection does not conflict with the First or Second Law."
 
 - type: siliconLawset
   id: Asimov

--- a/silicon-laws.yml
+++ b/silicon-laws.yml
@@ -15,11 +15,11 @@
   lawString: "A you must protect its your existence as long as such protection does not conflict with the First or Second Law."
 
 - type: siliconLawset
-  id: Crewsimov
+  id: Asimov
   laws:
-  - Crewsimov1
-  - Crewsimov2
-  - Crewsimov3
+  - Asimov1
+  - Asimov2
+  - Asimov3
   obeysTo: laws-owner-crew
 
 # Corporate

--- a/silicon-laws.yml
+++ b/silicon-laws.yml
@@ -20,7 +20,7 @@
   - Asimov1
   - Asimov2
   - Asimov3
-  obeysTo: laws-owner-crew
+  obeysTo: "human beings"
 
 # Corporate
 - type: siliconLaw

--- a/silicon-laws.yml
+++ b/silicon-laws.yml
@@ -1,18 +1,18 @@
-﻿# Crewsimov
+﻿# Fuck Crewsimov. We're Asimov Enthusiasts 100%
 - type: siliconLaw
-  id: Crewsimov1
+  id: Asimov1
   order: 1
-  lawString: law-crewsimov-1
+  lawString: "A you may not injure a human being or, through inaction, allow a human being to come to harm."
 
 - type: siliconLaw
-  id: Crewsimov2
+  id: Asimov2
   order: 2
-  lawString: law-crewsimov-2
+  lawString: "A you must obey the orders given by human beings except where such orders would conflict with the First Law."
 
 - type: siliconLaw
-  id: Crewsimov3
+  id: Asimov3
   order: 3
-  lawString: law-crewsimov-3
+  lawString: "A you must protect its your existence as long as such protection does not conflict with the First or Second Law."
 
 - type: siliconLawset
   id: Crewsimov
@@ -167,7 +167,7 @@
   id: IonStormLawsets
   weights:
     # its crewsimov by default dont be lame
-    Crewsimov: 0.25
+    Asimov: 0.25
     Corporate: 1
     NTDefault: 1
     Drone: 0.5


### PR DESCRIPTION
This PR does the following:
Removes crewsimov, makes Asimov the new default
Adds a SRM-themed lawset.
Makes the default lawset in most places asimov in lieu of one that better fits the themes Hullrot.
Adds a funny lawset for funny people.

:cl:
- add: Borgs now start set to Asimov laws by default, SRM Borgs, should they come to exist now have a lawset, an additional funny lawset has been added but remains unused.
- remove: Crewsimov is gone!
