### PR TITLE
Emags are Worth Buying Now

### DIFF
--- a/Entities/Objects/Tools/emag.yml
+++ b/Entities/Objects/Tools/emag.yml
@@ -12,6 +12,8 @@
   - type: Item
     sprite: Objects/Tools/emag.rsi
     storedRotation: -90
+    - type: StaticPrice
+    price: 7500
 
 
 - type: entity
@@ -20,5 +22,9 @@
   suffix: Limited
   components:
   - type: LimitedCharges
+    maxCharges: 666 #Let's make it an absurdly high number since you have to wait anyway
+    charges: 30
+  - type: AutoRecharge
+    rechargeDuration: 30
   - type: StaticPrice
     price: 2500

--- a/Entities/Objects/Tools/emag.yml
+++ b/Entities/Objects/Tools/emag.yml
@@ -23,7 +23,7 @@
   components:
   - type: LimitedCharges
     maxCharges: 666 #Let's make it an absurdly high number since you have to wait anyway
-    charges: 30
+    charges: 30 #Ships have a ton of airlocks + the thing's made for experimentation - you want to slap it on as many thing as possible
   - type: AutoRecharge
     rechargeDuration: 30
   - type: StaticPrice


### PR DESCRIPTION
Emags have been dogshit in vanilla for a while. Why is that, you might ask? Because Frontier 14 forked off of a build that never made emag charges recharge over time.

I've remedied that. Emags start off with 30 charges each now and recharge a single charge every 30 seconds up to a cap you'll never actually meet any in case. The basegame assumes you'll be slapping the emag on all sorts of objects + most ships have a great many doors, rendering a disposable, 3-use emag worthless if you want to get anything done. They're worthwhile now.