### PR TITLE
Fix vagrants not having access to Broadband radio channel

### DIFF
--- a/_NF/Entities/Objects/Devices/encryption_keys.yml
+++ b/_NF/Entities/Objects/Devices/encryption_keys.yml
@@ -7,7 +7,8 @@
   - type: EncryptionKey
     channels:
     - Traffic
-    defaultChannel: Traffic
+    - Common
+    defaultChannel: Common
   - type: Item
     sprite: _NF/Objects/Devices/encryption_keys.rsi
   - type: Sprite


### PR DESCRIPTION
Adds the "Common" channel to the traffic encryption key, allowing headsets with no faction-related encryption key to access 2.5km radio communications.