### PR TITLE
Nerf vibrokhopesh

### DIFF
--- a/_Crescent/Entities/Clothing/SRM/sword.yml
+++ b/_Crescent/Entities/Clothing/SRM/sword.yml
@@ -13,13 +13,13 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 33 #cmon, it has to be at least BETTER than the rest.
+        Slash: 32 #cmon, it has to be at least BETTER than the rest.
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
     enabled: true
-    reflectProb: .75
-    spread: 75
+    reflectProb: .25
+    spread: 100
   - type: Item
     size: Normal
     sprite: _Crescent/Objects/Weapons/vibrokhopesh.rsi

--- a/_Crescent/Entities/Clothing/SRM/sword.yml
+++ b/_Crescent/Entities/Clothing/SRM/sword.yml
@@ -18,7 +18,7 @@
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
     enabled: true
-    reflectProb: .25
+    reflectProb: .33
     spread: 100
   - type: Item
     size: Normal


### PR DESCRIPTION
changes reflect from 75% to 33% and increased the spread of reflected bullets
nerfs damage by 1 (from 33 to 32)

why? 75% reflect is fucking insane and srm already get op armor as well as no slips