### PR TITLE
Gives Cyberdawn Researchers Backpack Selection

### DIFF
--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -69,11 +69,6 @@
   - ContractorTrinkets
 
 - type: roleLoadout
-  id: JobCyberdawnTechNCSP
-  groups:
-  - ContractorTrinkets
-
-- type: roleLoadout
   id: JobLieutenantNCSP
   groups:
   - ContractorTrinkets
@@ -125,6 +120,12 @@
   groups:
   - ContractorTrinkets
   - SAWSBackpacks
+
+- type: roleLoadout
+  id: JobCyberdawnTechNCSP
+  groups:
+  - ContractorTrinkets
+  - NCSPBackpacks
 
 #empire
 


### PR DESCRIPTION
**What is this?**

Gives the regular CD role backpack loadout selections, between the regular NCSP ones (they only have the box in them). Moves them to the bottom of the NCSP loadouts list so they're no longer between Admin/Portboss, for the sake of neatness.

**Why is this good?**

Conforms to role standards for equipment, solves ['Cyberdawn researcher has NO gucci'](https://discord.com/channels/1194256269792510022/1315415200903594066/1315415200903594066). I'd give them their own backpack loadouts that match their colour scheme, but I can't find the source of where the backpack contents come from in the NC section, so have the red and black for now.