### PR TITLE
Gives DSM Knight Bannerets Their Armour

### DIFF
--- a/_Crescent/Roles/Jobs/DSM/knight.yml
+++ b/_Crescent/Roles/Jobs/DSM/knight.yml
@@ -44,7 +44,7 @@
     ears: ClothingHeadsetEmpire
     jumpsuit: ClothingUniformJumpsuitImperialCombat
     shoes: ClothingShoesBootsImperialJackboots
-    head: ClothingHeadHelmetImperialTrooperHelmet
-    outerClothing: ClothingOuterArmorImperialTrooperArmor
+    head: ClothingHeadHelmetImperialKnightCommanderHelmet
+    outerClothing: ClothingOuterArmorImperialArmorPrestige
     gloves: ClothingHandsGlovesImperialLonggloves
     pocket1: ImperialPassportBareLegit


### PR DESCRIPTION
**What is this?**

Knights currently spawn in the Man-At-Arms vest and helm. This changes it back to what it previously was, being the gold-trimmed armour and helm.

**Why is it good for the game?**

Makes knights visually different from men at arms pre-hardsuiting. Easier to spot them for new players to find guidance, and for regulars to find leaders.