### PR TITLE
Drops DSM Anathema Price to 40000

### DIFF
--- a/_Crescent/Entities/Objects/Misc/shiplpcs.yml
+++ b/_Crescent/Entities/Objects/Misc/shiplpcs.yml
@@ -115,7 +115,7 @@
     layers:
     - state: icon
   - type: StaticPrice
-    price: 70000
+    price: 45000
   - type: ShipVoucher
     ship: Anathema
 

--- a/_Crescent/Maps/Ships/DSM/anathema.yml
+++ b/_Crescent/Maps/Ships/DSM/anathema.yml
@@ -2,7 +2,7 @@
   id: Anathema
   name: DSM Anathema
   description: A light battlecarrier with the capacity to print strikeshuttles.
-  price: 60000
+  price: 40000
   category: Medium
   group: None
   shuttlePath: /Maps/_Crescent/Shuttles/DSM/anathema.yml


### PR DESCRIPTION
**What is this?**

Drops the DSM military shipyard console price for the DSM Anathema to 40k, down from 60k.

**Why is this good?**

The Anathema had it's two hardliners replaced with 400c plasma repeaters, it's five plasma gatlings replaced with mining lasers, and is effectively made of paper against anything that has more than a gatling. The Valors spawned from it aren't provided with enough spare missiles aboard the Anathema to effectively rearm, so the only actual use for it as a mothership is as a Conquest-spawning boat, and PD to ward off a small number of Ultralights. The decrease in cost reflects the loss of weaponry that would justify it, alongside the attack/defence power of newer-implemented ships (both lighter and heavier) that it comes up against that it can't contest. I'm the only one that has bought Anathemas in the last two or so months (to check these things out and see how it fares), so maybe cheapening it will encourage it's use with the Conq/Valor, instead of Ibis/Janni swarms.