### PR TITLE
Fix Idna ammo being impossible to attain; restore Sumitomo ammo to NCWL

### DIFF
--- a/_Crescent/Catalog/Cargo/Freeport/ammunition.yml
+++ b/_Crescent/Catalog/Cargo/Freeport/ammunition.yml
@@ -9,6 +9,16 @@
   group: freeport
 
 - type: cargoProduct
+  id: ShuttleIdnaAmmoFreeport
+  icon:
+    sprite: _Crescent/Objects/ShuttleWeapons/torpedop.rsi
+    state: base
+  product: CrateIdnaAmmo
+  cost: 12000
+  category: cargoproduct-category-name-shuttle
+  group: freeport
+
+- type: cargoProduct
   id: ShuttleCrateVulcanAmmoFreeport
   icon:
     sprite: _Crescent/Ammunition/vulcan.rsi

--- a/_Crescent/Catalog/Cargo/cargo_shuttle.yml
+++ b/_Crescent/Catalog/Cargo/cargo_shuttle.yml
@@ -1,22 +1,22 @@
-#- type: cargoProduct
-#  id: ShuttleSumitomoAmmo
-#  icon:
-#    sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
-#    state: baton
-#  product: CrateSumitomoAmmo
-#  cost: 12500
-#  category: cargoproduct-category-name-shuttle
-#  group: market
+- type: cargoProduct
+  id: ShuttleSumitomoAmmo
+  icon:
+    sprite: Objects/Weapons/Guns/Ammunition/Explosives/explosives.rsi
+    state: baton
+  product: CrateSumitomoAmmo
+  cost: 15000
+  category: cargoproduct-category-name-shuttle
+  group: market
 
-#- type: cargoProduct
-#  id: ShuttleIdnaAmmo
-#  icon:
-#    sprite: _Crescent/Objects/ShuttleWeapons/torpedop.rsi
-#    state: base
-#  product: CrateIdnaAmmo
-#  cost: 9000
-#  category: cargoproduct-category-name-shuttle
-#  group: market
+- type: cargoProduct
+  id: ShuttleIdnaAmmo
+  icon:
+    sprite: _Crescent/Objects/ShuttleWeapons/torpedop.rsi
+    state: base
+  product: CrateIdnaAmmo
+  cost: 12000
+  category: cargoproduct-category-name-shuttle
+  group: market
 
 - type: cargoProduct
   id: ShuttleGargoyleAmmo


### PR DESCRIPTION
Idna torpedo ammo cannot be manufactured nor purchased through any faction's cargo console. Likewise, Sumitomo torpedo ammo cannot be purchased from the NCWL cargo console. This restores access to Idna ammo for NCWL and TFSC (in accordance with a @cherubdev comment that NCWL and TFSC should have access to Idna ammo while DSM should not) and restores access to Sumitomo ammo for NCWL. Prices are raised to better match other ammo listings.