### PR TITLE
makes vagrant no longer be a noob trap

### DIFF
--- a/_Crescent/Roles/Jobs/Shared/contractor.yml
+++ b/_Crescent/Roles/Jobs/Shared/contractor.yml
@@ -3,6 +3,9 @@
   name: job-name-contractor
   description: job-description-contractor
   playTimeTracker: JobContractor
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 4000
   startingGear: ContractorGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-hire


### PR DESCRIPTION
adds a small overall playtime requirement to vagrants, this is to stop brand new players from picking it and getting stuck in the noob trap that is the freeport and the anthead.