### PR TITLE
Remove speed modifier from voidsuits/NON space suits(NO VACUUM PROTECTION)

### DIFF
--- a/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -20,8 +20,8 @@
     slots:
     - outerClothing
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 1
+    sprintModifier: 1
   - type: HeldSpeedModifier
 
 - type: entity
@@ -154,9 +154,6 @@
     lowPressureMultiplier: 1000
   - type: TemperatureProtection
     coefficient: 0.01 # Not complete protection from fire
-  - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: Item
     size: Huge

--- a/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -19,10 +19,6 @@
   - type: Clothing
     slots:
     - outerClothing
-  - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
-  - type: HeldSpeedModifier
 
 - type: entity
   abstract: true

--- a/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/onion.yml
@@ -24,6 +24,8 @@
     C4: 10
     PipeBomb: 5
     EmpGrenade: 5
+    ExGrenade: 5
+    Minibomb: 5
     OnionMachineRestock: 15
     StorageImplanter: 2
     FreedomImplanter: 10


### PR DESCRIPTION
Remove speed modifier from voidsuits. buff speed of nonspace suits to 1 from .9, some suits downstream appear to have their own modifiers.