### PR TITLE
PD turret velocity buff

### DIFF
--- a/_Crescent/Entities/Structures/turrets.yml
+++ b/_Crescent/Entities/Structures/turrets.yml
@@ -61,7 +61,7 @@
                   max: 5
     - type: TurretIFF
     - type: Gun
-      projectileSpeed: 80
+      projectileSpeed: 125 
       fireRate: 5
       selectedMode: FullAuto
       availableModes:
@@ -221,7 +221,7 @@
                   max: 5
     - type: Gun
       fireRate: 9.5
-      projectileSpeed: 85
+      projectileSpeed: 175 # 85 vel is nowhere near enough to hit anything lol
       selectedMode: FullAuto
       availableModes:
         - FullAuto


### PR DESCRIPTION
the PD velocity was so ass you couldnt hit shit with it lol.
the bullets took like 8 seconds to move 200 meters, a capital ship could outmanuver them at that range and you want to hit ULs/guided missiles with this?

again, if this is too much/too little tell me. if it ends up being ass we can just revert it.