### PR TITLE
drug fixes plus nerf

### DIFF
--- a/_Crescent/Entities/Objects/Smuggling/drugs.yml
+++ b/_Crescent/Entities/Objects/Smuggling/drugs.yml
@@ -53,8 +53,6 @@
         reagents:
         - ReagentId: Exile
           Quantity: 25
-        - ReagentId: Omnizine
-          Quantity: 5
         - ReagentId: TranexamicAcid
           Quantity: 5
   - type: Tag
@@ -90,8 +88,6 @@
           Quantity: 25
         - ReagentId: Ephedrine
           Quantity: 15
-        - ReagentId: TranexamicAcid
-          Quantity: 5
   - type: Tag
     tags: []
   - type: Contraband
@@ -122,9 +118,7 @@
         maxVol: 40
         reagents:
         - ReagentId: Mechanites
-          Quantity: 25
-        - ReagentId: Omnizine
-          Quantity: 15
+          Quantity: 35
         - ReagentId: TranexamicAcid
           Quantity: 5
   - type: Tag
@@ -156,13 +150,9 @@
         maxVol: 45
         reagents:
         - ReagentId: Bloodeye
-          Quantity: 20
+          Quantity: 30
         - ReagentId: Crash
-          Quantity: 10
-        - ReagentId: Stimulants
           Quantity: 15
-        - ReagentId: Impedrezene
-          Quantity: 5
   - type: Tag
     tags: []
   - type: Contraband

--- a/_Crescent/Entities/Reagents/narcotics.yml
+++ b/_Crescent/Entities/Reagents/narcotics.yml
@@ -139,7 +139,7 @@
         conditions:
         - !type:ReagentThreshold
             min: 25
-        amount: 30000
+        amount: 100000
       
 
 - type: reagent

--- a/_Crescent/Entities/Reagents/narcotics.yml
+++ b/_Crescent/Entities/Reagents/narcotics.yml
@@ -17,10 +17,10 @@
     Narcotic:
       effects:
       - !type:ChemVomit
-        probability: 0.2
+        probability: 0.05
       - !type:MovespeedModifier
         walkSpeedModifier: 1.35
-        sprintSpeedModifier: 2 # you vomit so much that you are lucky if you get more than 1.4 speed out of this at any time.
+        sprintSpeedModifier: 1.7 
       - !type:GenericStatusEffect
         key: Stutter
         component: StutteringAccent
@@ -35,16 +35,16 @@
         type: Remove
       - !type:Emote
         emote: Scream
-        probability: 0.05
+        probability: 0.1
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-            min: 35
+            min: 15
         amount: 20000 # ups temp by like 20c per unit of OD
       - !type:Emote
         emote: Crying
         showInChat: true
-        probability: 0.7
+        probability: 0.25
         conditions:
         - !type:ReagentThreshold
           min: 15
@@ -82,10 +82,15 @@
           max: 50
         damage:
           groups:
-            Brute: -2 # heals 4 per unit at 2 per second and heals less per unit
+            Brute: -2
             Burn: -1
     Narcotic:
       effects:
+      - !type:AdjustTemperature
+        conditions:
+        - !type:ReagentThreshold
+            min: 25
+        amount: 20000 # ups temp by like 20c per unit of OD
       - !type:GenericStatusEffect
         key: SeeingRainbows
         component: SeeingRainbows
@@ -93,8 +98,8 @@
         time: 6
         refresh: false
       - !type:MovespeedModifier
-        walkSpeedModifier: 1.5
-        sprintSpeedModifier: 1.6
+        walkSpeedModifier: 1.25
+        sprintSpeedModifier: 1.5
       - !type:GenericStatusEffect
         key: Stutter
         component: StutteringAccent
@@ -124,13 +129,13 @@
       - !type:HealthChange
         damage:
           groups:
-            Brute: -16 # heals 16 per unit at 16 per second
+            Brute: -16
             Burn: -1
             Airloss: -2
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-            min: 40
+            min: 25
         amount: 30000 # ups temp by like 15c per half a second of overdosing
       
 
@@ -149,7 +154,7 @@
       - !type:HealthChange
         damage:
           groups:
-            Brute: -4 # heals 8 per unit at 4 per second
+            Brute: -4 
           types:
             Poison: -2.0
             Heat: -0.6
@@ -173,12 +178,12 @@
   color: "#FF7F7F"
   metabolisms:
     Medicine:
-      metabolismRate: 1 # makes the stim last half as long and heals less per unit
+      metabolismRate: 1 
       effects:
       - !type:HealthChange
         damage:
           groups:
-            Brute: -8 # heals 8 per unit at 8 per second
+            Brute: -8 
             Airloss: -2
       - !type:ResetNarcolepsy
         conditions:
@@ -189,5 +194,5 @@
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-            min: 40
+            min: 30
         amount: 10000 # ups temp by like 5c per half a second of overdosing

--- a/_Crescent/Entities/Reagents/narcotics.yml
+++ b/_Crescent/Entities/Reagents/narcotics.yml
@@ -132,9 +132,11 @@
       - !type:HealthChange
         damage:
           groups:
-            Brute: -16
+            Brute: -15
             Burn: -1
             Airloss: -2
+          types:
+            Piercing: -10
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold

--- a/_Crescent/Entities/Reagents/narcotics.yml
+++ b/_Crescent/Entities/Reagents/narcotics.yml
@@ -18,9 +18,12 @@
       effects:
       - !type:ChemVomit
         probability: 0.05
+        conditions:
+        - !type:ReagentThreshold
+            min: 10
       - !type:MovespeedModifier
         walkSpeedModifier: 1.35
-        sprintSpeedModifier: 1.7 
+        sprintSpeedModifier: 1.6 
       - !type:GenericStatusEffect
         key: Stutter
         component: StutteringAccent
@@ -35,16 +38,16 @@
         type: Remove
       - !type:Emote
         emote: Scream
-        probability: 0.1
+        probability: 0.25
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
             min: 15
-        amount: 20000 # ups temp by like 20c per unit of OD
+        amount: 50000 
       - !type:Emote
-        emote: Crying
+        emote: Scream
         showInChat: true
-        probability: 0.25
+        probability: 0.5
         conditions:
         - !type:ReagentThreshold
           min: 15
@@ -90,7 +93,7 @@
         conditions:
         - !type:ReagentThreshold
             min: 25
-        amount: 20000 # ups temp by like 20c per unit of OD
+        amount: 50000 
       - !type:GenericStatusEffect
         key: SeeingRainbows
         component: SeeingRainbows
@@ -136,7 +139,7 @@
         conditions:
         - !type:ReagentThreshold
             min: 25
-        amount: 30000 # ups temp by like 15c per half a second of overdosing
+        amount: 30000
       
 
 - type: reagent
@@ -195,4 +198,4 @@
         conditions:
         - !type:ReagentThreshold
             min: 30
-        amount: 10000 # ups temp by like 5c per half a second of overdosing
+        amount: 50000 

--- a/_Crescent/Entities/Recipes/Lathes/drugz.yml
+++ b/_Crescent/Entities/Recipes/Lathes/drugz.yml
@@ -14,7 +14,7 @@
   completetime: 1
   materials:
     ExoticProteins: 1500
-    RefinedGarbage: 2000
+    RefinedGarbage: 1000
     DeactivatedPhoron: 1000 
     Galine: 250
 
@@ -24,10 +24,10 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    ExoticProteins: 2000
+    ExoticProteins: 1250
     PlasmaIsotope: 1500
-    DeactivatedPhoron: 1000
-    Galine: 500
+    DeactivatedPhoron: 1750
+    Galine: 1000
 
 - type: latheRecipe
   id: Mechanite
@@ -45,10 +45,9 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    ExoticProteins: 1500
-    Galine: 500
-    DeactivatedPhoron: 1000 
-    RefinedGarbage: 2000
+    ExoticProteins: 1000
+    Galine: 1500
+    RefinedGarbage: 1000
 
 - type: latheRecipe
   id: PartyDrugs

--- a/_Crescent/Entities/Recipes/Lathes/drugz.yml
+++ b/_Crescent/Entities/Recipes/Lathes/drugz.yml
@@ -15,8 +15,8 @@
   materials:
     ExoticProteins: 1500
     PlasmaIsotope: 500
-    RefinedGarbage: 2000
-    DeactivatedPhoron: 1000 
+    RefinedGarbage: 1750
+    DeactivatedPhoron: 750
     Galine: 250
 
 - type: latheRecipe
@@ -49,7 +49,7 @@
     ExoticProteins: 1500
     Galine: 500
     DeactivatedPhoron: 1000 
-    RefinedGarbage: 2000
+    RefinedGarbage: 1750
 
 - type: latheRecipe
   id: PartyDrugs

--- a/_Crescent/Entities/Recipes/Lathes/drugz.yml
+++ b/_Crescent/Entities/Recipes/Lathes/drugz.yml
@@ -54,7 +54,7 @@
   id: PartyDrugs
   result: TradeGoodDrugs
   applyMaterialDiscount: false
-  completetime: 1
+  completetime: 2
   materials:
     PlasmaIsotope: 1000
     Galine: 500

--- a/_Crescent/Entities/Recipes/Lathes/drugz.yml
+++ b/_Crescent/Entities/Recipes/Lathes/drugz.yml
@@ -14,6 +14,7 @@
   completetime: 1
   materials:
     ExoticProteins: 1500
+    PlasmaIsotope: 500
     RefinedGarbage: 2000
     DeactivatedPhoron: 1000 
     Galine: 250

--- a/_Crescent/Entities/Recipes/Lathes/drugz.yml
+++ b/_Crescent/Entities/Recipes/Lathes/drugz.yml
@@ -14,7 +14,7 @@
   completetime: 1
   materials:
     ExoticProteins: 1500
-    RefinedGarbage: 1000
+    RefinedGarbage: 2000
     DeactivatedPhoron: 1000 
     Galine: 250
 
@@ -24,7 +24,7 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    ExoticProteins: 1250
+    ExoticProteins: 2000
     PlasmaIsotope: 1500
     DeactivatedPhoron: 1750
     Galine: 1000
@@ -45,15 +45,16 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    ExoticProteins: 1000
-    Galine: 1500
-    RefinedGarbage: 1000
+    ExoticProteins: 1500
+    Galine: 500
+    DeactivatedPhoron: 1000 
+    RefinedGarbage: 2000
 
 - type: latheRecipe
   id: PartyDrugs
   result: TradeGoodDrugs
   applyMaterialDiscount: false
-  completetime: 2
+  completetime: 1
   materials:
     PlasmaIsotope: 1000
     Galine: 500

--- a/_Crescent/Entities/Recipes/Lathes/drugz.yml
+++ b/_Crescent/Entities/Recipes/Lathes/drugz.yml
@@ -2,27 +2,29 @@
   id: Crash
   result: CrashAutoinjector
   applyMaterialDiscount: false
-  completetime: 2
+  completetime: 1
   materials:
-    Garbage: 2250
-    DeactivatedPhoron: 500
+    RefinedGarbage: 2000
+    ExoticProteins: 750
 
 - type: latheRecipe
   id: Exile
   result: ExileAutoinjector
   applyMaterialDiscount: false
-  completetime: 2
+  completetime: 1
   materials:
-    RefinedGarbage: 2500
-    DeactivatedPhoron: 1000
+    ExoticProteins: 1500
+    RefinedGarbage: 2000
+    DeactivatedPhoron: 1000 
     Galine: 250
 
 - type: latheRecipe
   id: Kaiser
   result: KaiserAutoinjector
   applyMaterialDiscount: false
-  completetime: 2
+  completetime: 1
   materials:
+    ExoticProteins: 2000
     PlasmaIsotope: 1500
     DeactivatedPhoron: 1000
     Galine: 500
@@ -31,22 +33,22 @@
   id: Mechanite
   result: MechaniteAutoinjector
   applyMaterialDiscount: false
-  completetime: 2
+  completetime: 1
   materials:
     PlasmaIsotope: 1250
-    Galine: 250
-    Mechanites: 3000
+    Galine: 500
+    Mechanites: 2000
 
 - type: latheRecipe
   id: Bloodeye
   result: BloodeyeAutoinjector
   applyMaterialDiscount: false
-  completetime: 2
+  completetime: 1
   materials:
-    PlasmaIsotope: 1250
-    Galine: 550
-    DeactivatedPhoron: 1000
-    RefinedGarbage: 1000
+    ExoticProteins: 1500
+    Galine: 500
+    DeactivatedPhoron: 1000 
+    RefinedGarbage: 2000
 
 - type: latheRecipe
   id: PartyDrugs

--- a/_Crescent/Entities/Recipes/Lathes/drugz.yml
+++ b/_Crescent/Entities/Recipes/Lathes/drugz.yml
@@ -4,8 +4,9 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    RefinedGarbage: 2000
-    ExoticProteins: 750
+    ExoticProteins: 250
+    DeactivatedPhoron: 500
+    Garbage: 1750
 
 - type: latheRecipe
   id: Exile
@@ -13,11 +14,11 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    ExoticProteins: 1500
-    PlasmaIsotope: 500
-    RefinedGarbage: 1750
-    DeactivatedPhoron: 750
     Galine: 250
+    PlasmaIsotope: 500
+    DeactivatedPhoron: 500
+    ExoticProteins: 1000
+    RefinedGarbage: 1500
 
 - type: latheRecipe
   id: Kaiser
@@ -25,10 +26,10 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    ExoticProteins: 2000
-    PlasmaIsotope: 1500
-    DeactivatedPhoron: 1750
     Galine: 1000
+    ExoticProteins: 1500
+    DeactivatedPhoron: 1500
+    PlasmaIsotope: 2000
 
 - type: latheRecipe
   id: Mechanite
@@ -36,8 +37,9 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    PlasmaIsotope: 1250
     Galine: 500
+    PlasmaIsotope: 1000
+    DeactivatedPhoron: 1500
     Mechanites: 2000
 
 - type: latheRecipe
@@ -46,10 +48,10 @@
   applyMaterialDiscount: false
   completetime: 1
   materials:
-    ExoticProteins: 1500
     Galine: 500
     DeactivatedPhoron: 1000 
-    RefinedGarbage: 1750
+    ExoticProteins: 1500
+    RefinedGarbage: 2000
 
 - type: latheRecipe
   id: PartyDrugs
@@ -57,7 +59,7 @@
   applyMaterialDiscount: false
   completetime: 2
   materials:
-    PlasmaIsotope: 1000
     Galine: 500
+    PlasmaIsotope: 1000
     DeactivatedPhoron: 1500
     RefinedGarbage: 1500


### PR DESCRIPTION
IPM nerf brought to you by the IPM FL :trollface: 

most species cant process more than two reagents at a time so i just made each stim only contain two reagents, tightened the ODs so you will OD much easier, added a much needed OD to exile.
got rid of a bunch of old, innacurate comments i left too

nerfed production costs, most now also include exotic protiens, which puts a soft limit on how many drugs can be made.
also sped up production time for QOL.
only buff is mechanites are about 20% cheaper to produce.

tldr:
nerfs:
drug ODs are more punishing
Exile has a proper OD now
most drugs only contain either omni or tranex as a side chem to the main one instead of 2-3 others.
crash doesnt make you go as fast as it used to
exile doesnt make you go as fast as it used to
crash, exile and bloodeye all cost additional exotic protiens
kaiser, blood eye and exile all cost more smuggled goods to create
crash costs compacted trash instead of uncompacted
crash costs exotic protiens instead of phoron
blood eye costs more to make in addition to reqiring exotic protiens
buffs:
crash has a lower chance to make you vomit
lowered production cost of mechanites
Kaiser heals more peirce now (in testing it healed 25 per stim, i miscalculated how much when making it at first, now it should heal about 40-50 but should probably test this :trollface:)
drug production time is doubled (QOL)

exotic protiens are aquired by gibbing players (mobs dont work, only players) which means theres a soft limit on how many drugs IPM can make based on how many corpses end up at the freeport.