### PR TITLE
Breakable cryo sleep pod

### DIFF
--- a/_NF/Entities/Structures/Machines/cryopod.yml
+++ b/_NF/Entities/Structures/Machines/cryopod.yml
@@ -29,3 +29,25 @@
   - type: ContainerContainer
     containers:
       body_container: !type:ContainerSlot
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SteelScrap1:
+            min: 1
+            max: 2

--- a/_NF/Entities/Structures/Machines/cryopod.yml
+++ b/_NF/Entities/Structures/Machines/cryopod.yml
@@ -33,13 +33,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 600
+        damage: 200
       behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 100
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
Make the cryo sleep pods no longer invincible and floating out in space when the rest of the ship/station is in ruin if they take enough damage. Double checked glass damages and machine damages before reuploading, put it more in line with other equipment.