### PR TITLE
Give NCWL Admiral Kommisar access

### DIFF
--- a/_Crescent/Roles/Jobs/NCWL/administrator.yml
+++ b/_Crescent/Roles/Jobs/NCWL/administrator.yml
@@ -56,6 +56,7 @@
   - Service
   - External
   - NCWLAdministrator
+  - NCWLKommissar
   - NCWLGeneral
   - NCWLArmory
   - NCWLCommand


### PR DESCRIPTION
why doesn't he have it??

The admiral having to break into the armory is bad gameplay