### PR TITLE
Make rocks take structural damage

### DIFF
--- a/Entities/Structures/Walls/asteroid.yml
+++ b/Entities/Structures/Walls/asteroid.yml
@@ -379,8 +379,8 @@
         tags:
           - Pickaxe
     - type: Damageable
-      damageContainer: Inorganic
-      damageModifierSet: Metallic
+      damageContainer: StructuralInorganic
+      damageModifierSet: Rock
     - type: Destructible
       thresholds:
         - trigger:


### PR DESCRIPTION
The rocks we use for asteroids have a damageContainer that doesn't allow them to take structural damage.
This PR allows rocks to take structural damage and changes their resistances to the rock resistances for mysterious reasons.