### PR TITLE
Make smuggling great again

### DIFF
--- a/_Crescent/Entities/Objects/Misc/space_cash.yml
+++ b/_Crescent/Entities/Objects/Misc/space_cash.yml
@@ -8,3 +8,14 @@
     state: cash_1000
   - type: Stack
     count: 350
+
+- type: entity
+  parent: SpaceCash
+  id: SpaceCash12500
+  suffix: 12500
+  components:
+  - type: Icon
+    sprite: Objects/Economy/cash.rsi
+    state: cash_1000
+  - type: Stack
+    count: 12500

--- a/_Crescent/Entities/Structures/dispensers.yml
+++ b/_Crescent/Entities/Structures/dispensers.yml
@@ -268,9 +268,9 @@
       WeaponPistolHimehabu: SpaceCash2500
       WeaponPistolComplianceImperial: SpaceCash2500
       WeaponPistolSmartpistol: SpaceCash2500
-      TradeGoodOrgans: SpaceCash10000
-      TradeGoodDrugs: SpaceCash8000
-      FoodAmbrosiaVulgaris: SpaceCash350
+      TradeGoodOrgans: SpaceCash20000
+      TradeGoodDrugs: SpaceCash12500
+      FoodAmbrosiaVulgaris: SpaceCash1000
   - type: Sprite
     sprite: _Crescent/Structures/onionchute.rsi
     layers:


### PR DESCRIPTION
average max profits in the past were 300k a round from organ crates not including ship costs, bribes and other fees, doubling it makes it 600k a round, the absolute maximum i have ever seen in a round was about 60 crates which comes out to 1.2 million.
smuggling is very high risk and MLG has said they might make it higher risk in the future so i think this is fair.

if MLG thinks i have overtuned it they can just set it to whatever they think is a good price