### PR TITLE
Breakable Cryopod 4

### DIFF
--- a/_NF/Entities/Structures/Machines/cryopod.yml
+++ b/_NF/Entities/Structures/Machines/cryopod.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: MachineCryoSleepPod
-  parent: [BaseStructureDisableToolUse, BaseStructureDestructible, BaseMachine]
+  parent: [BaseMachine]
   name: cryo sleep chamber
   description: cold pillow guaranteed
   components:


### PR DESCRIPTION
Removed BaseStructuredisabletooluse and basestructuredestructible, should be good with only basemachine. Kept damage values in as they are different from the parent