### PR TITLE
Upgrade scanner range for new gun ranges

### DIFF
--- a/Entities/Structures/Machines/Computers/computers.yml
+++ b/Entities/Structures/Machines/Computers/computers.yml
@@ -148,7 +148,7 @@
     tags:
       - Syndicate
   - type: RadarConsole
-    maxRange: 384
+    maxRange: 484
   - type: WorldLoader
     radius: 1536
   - type: PointLight
@@ -179,7 +179,7 @@
     components:
       - type: CargoShuttle
   - type: RadarConsole
-    maxRange: 256
+    maxRange: 356
   - type: PointLight
     radius: 1.5
     energy: 1.6
@@ -210,7 +210,7 @@
       components:
         - type: SalvageShuttle
     - type: RadarConsole
-      maxRange: 256
+      maxRange: 356
     - type: PointLight
       radius: 1.5
       energy: 1.6
@@ -702,7 +702,7 @@
     - map: ["computerLayerKeys"]
       state: generic_keys
   - type: RadarConsole
-    maxRange: 256 # Frontier
+    maxRange: 356 # Frontier
   - type: ActivatableUI
     key: enum.RadarConsoleUiKey.Key
   - type: UserInterface
@@ -725,7 +725,7 @@
   - type: Computer
     board: AdvancedRadarConsoleCircuitboard
   - type: RadarConsole
-    maxRange: 768
+    maxRange: 1024 # Frontier
   - type: Sprite
     layers:
     - map: ["computerLayerBody"]


### PR DESCRIPTION
please allow some sort of updated scanner ranges since guns can fire much further range now. this still means iff cloaked ships can fire beyond radar just not 2x range