### PR TITLE
rocket fix

### DIFF
--- a/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -702,7 +702,7 @@
 
 - type: entity
   id: BulletGrenadeBaton
-  name: low-yield missile
+  name: low-yield rocket
   parent: BaseBulletTrigger
   categories: [ HideSpawnMenu ]
   components:
@@ -720,7 +720,7 @@
 
 - type: entity
   id: BulletGrenadeBlast
-  name: high-yield missile
+  name: high-yield rocket
   parent: BaseBulletTrigger
   categories: [ HideSpawnMenu ]
   components:
@@ -738,7 +738,7 @@
 
 - type: entity
   id: BulletGrenadeFlash
-  name: flash missile
+  name: flash rocket
   parent: BaseBulletTrigger
   categories: [ HideSpawnMenu ]
   components:

--- a/Entities/Structures/Machines/lathe.yml
+++ b/Entities/Structures/Machines/lathe.yml
@@ -864,6 +864,7 @@
         - SluggieAP
         - Automortar90
         - GrenadeBlast
+        - GrenadeBatonCraft
         - GrenadeEMP
         - MagazineGrenadeEmpty
         - Needler60

--- a/_Crescent/Catalog/Fills/Crates/shuttleammo.yml
+++ b/_Crescent/Catalog/Fills/Crates/shuttleammo.yml
@@ -13,9 +13,7 @@
       - id: GrenadeBlast
         amount: 6
       - id: GrenadeBaton
-        amount: 6
-      - id: GrenadeFlash
-        amount: 6
+        amount: 12
 
 - type: entity
   id: CrateGargoyleAmmo

--- a/_Crescent/Entities/Recipes/Lathes/ammo.yml
+++ b/_Crescent/Entities/Recipes/Lathes/ammo.yml
@@ -68,3 +68,10 @@
   completetime: 2
   materials:
     Steel: 750
+
+- type: latheRecipe
+  id: GrenadeBatonCraft
+  result: GrenadeBaton
+  completetime: 4
+  materials:
+    Steel: 500

--- a/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
+++ b/_Crescent/Entities/Recipes/Lathes/communardcrafts.yml
@@ -220,13 +220,6 @@
     Plastic: 2500
     Silver: 1000
 
-- type: latheRecipe
-  id: GrenadeBatonCraft
-  result: GrenadeBaton
-  completetime: 4
-  materials:
-    Steel: 500
-
 # - type: latheRecipe
 #   id: GrenadeBlastCraft
 #   result: GrenadeBlast #YAMLFIX: needs new result entity to not fail tests

--- a/_Crescent/Entities/Structures/lathe.yml
+++ b/_Crescent/Entities/Structures/lathe.yml
@@ -241,7 +241,6 @@
       - FlashPayload
       - GrenadeBlast
       - GrenadeEMP
-      - GrenadeFlash
       - HoloprojectorSecurity
       - MagazineBoxLightRifleIncendiary
       - MagazineBoxLightRifleUranium


### PR DESCRIPTION
renames rockets to rockets instead of missiles (they dont track or self propel)
adds low yield rockets to ammo techfab (they had emp and HY but not LY)
removes flash rockets from microforge
swaps flash rockets in sumitomo crate for low yields
move low yield craft from commie dedicated file to general ammo file since everyone uses it (you should also consider moving the other crafts over instead of overwriting the wizden values)