### PR TITLE
Adds .327 Submachine magazines (Liberator Mag) to craftings/vendors

### DIFF
--- a/Entities/Structures/Machines/lathe.yml
+++ b/Entities/Structures/Machines/lathe.yml
@@ -870,6 +870,7 @@
         - MagazineVulcan
         - MagazineFlak
         - MagazinePistolSubMachineGun
+        - MagazineMagnumSub
         - BoxLethalshot
         - BoxShotgunFlare
         - BoxShotgunSlug

--- a/Recipes/Lathes/security.yml
+++ b/Recipes/Lathes/security.yml
@@ -233,6 +233,16 @@
   materials:
     Steel: 300
 
+
+- type: latheRecipe
+  id: MagazineMagnumSub
+  result: MagazineMagnumSub
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 300
+    
+
 - type: latheRecipe
   id: MagazinePistolSubMachineGunTopMountedEmpty
   result: MagazinePistolSubMachineGunTopMountedEmpty

--- a/_Crescent/Catalog/VendingMachines/Inventories/ncwlarmory.yml
+++ b/_Crescent/Catalog/VendingMachines/Inventories/ncwlarmory.yml
@@ -16,4 +16,5 @@
     MagazineRifle: 25
     MagazineLightRifle: 25
     MagazinePistolSubMachineGun: 25
+    MagazineMagnumSub: 25
     MagazineMagnum: 25

--- a/_Crescent/Entities/Structures/lathe.yml
+++ b/_Crescent/Entities/Structures/lathe.yml
@@ -154,6 +154,7 @@
       - MagazineRifle
       - MagazineShotgun
       - MagazineShotgunSlug
+      - MagazineMagnumSub
       - Wirecutter
       - Igniter
       - Signaller


### PR DESCRIPTION
Adds .327 Submachine Magazine that the Liberator uses to:
-Ammo TechFab
-Pristine Microforge
-NCWL Armory vendor