### PR TITLE
Adds NCWL Loadouts + Hypos

### DIFF
--- a/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Catalog/VendingMachines/Inventories/medical.yml
@@ -7,6 +7,7 @@
     Bloodpack: 15
     EpinephrineChemistryBottle: 6
     Syringe: 4
+    HypoMini: 8
     BodyBagFolded: 12
     ClothingEyesHudMedical: 5
     ClothingEyesEyepatchHudMedical: 5

--- a/_Crescent/Loadouts/Jobs/AdmiralNCWL/head.yml
+++ b/_Crescent/Loadouts/Jobs/AdmiralNCWL/head.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: AdminClothingHeadHatNCWLBeret
+  equipment: AdminClothingHeadHatNCWLBeret
+  price: 0
+
+- type: startingGear
+  id: AdminClothingHeadHatNCWLBeret
+  equipment:
+    head: AdministratorClothingHeadHatNCWLBeret

--- a/_Crescent/Loadouts/Jobs/Contractor/tools.yml
+++ b/_Crescent/Loadouts/Jobs/Contractor/tools.yml
@@ -175,7 +175,7 @@
   effects:
   - !type:GroupLoadoutEffect
     proto: ContractorT2
-  price: 5000
+  price: 2500
 
 - type: startingGear
   id: ContractorHypoMini

--- a/_Crescent/Loadouts/Jobs/DoktorNCWL/head.yml
+++ b/_Crescent/Loadouts/Jobs/DoktorNCWL/head.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: DoktorClothingHeadHatNCWLCapsoftMedical
+  equipment: DoktorClothingHeadHatNCWLCapsoftMedical
+  price: 0
+
+- type: startingGear
+  id: DoktorClothingHeadHatNCWLCapsoftMedical
+  equipment:
+    head: ClothingHeadHatNCWLCapsoftMedical

--- a/_Crescent/Loadouts/Jobs/KapitanNCWL/head.yml
+++ b/_Crescent/Loadouts/Jobs/KapitanNCWL/head.yml
@@ -6,4 +6,4 @@
 - type: startingGear
   id: KapitanClothingHeadHatNCWLBeret
   equipment:
-    jumpsuit: ClothingHeadHatNCWLBereta
+    head: ClothingHeadHatNCWLBeret

--- a/_Crescent/Loadouts/Jobs/KapitanNCWL/head.yml
+++ b/_Crescent/Loadouts/Jobs/KapitanNCWL/head.yml
@@ -6,4 +6,4 @@
 - type: startingGear
   id: KapitanClothingHeadHatNCWLBeret
   equipment:
-    jumpsuit: ClothingHeadHatNCWLBeretaa
+    jumpsuit: ClothingHeadHatNCWLBereta

--- a/_Crescent/Loadouts/Jobs/KapitanNCWL/head.yml
+++ b/_Crescent/Loadouts/Jobs/KapitanNCWL/head.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: KapitanClothingHeadHatNCWLBeret
+  equipment: KapitanClothingHeadHatNCWLBeret
+  price: 0
+
+- type: startingGear
+  id: KapitanClothingHeadHatNCWLBeret
+  equipment:
+    jumpsuit: ClothingHeadHatNCWLBeretaa

--- a/_Crescent/Loadouts/Jobs/KapitanNCWL/outer.yml
+++ b/_Crescent/Loadouts/Jobs/KapitanNCWL/outer.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: ClothingOuterArmorNCWLCarapaceKapitan
+  equipment: ClothingOuterArmorNCWLCarapaceKapitan
+  price: 0
+
+- type: startingGear
+  id: SanitarNCWLClothingUniformJumpsuitNCWL
+  equipment:
+    jumpsuit: ClothingOuterArmorNCWLCarapaceKapitan

--- a/_Crescent/Loadouts/Jobs/KapitanNCWL/outer.yml
+++ b/_Crescent/Loadouts/Jobs/KapitanNCWL/outer.yml
@@ -6,4 +6,4 @@
 - type: startingGear
   id: StartClothingOuterArmorNCWLCarapaceKapitan
   equipment:
-    jumpsuit: ClothingOuterArmorNCWLCarapaceKapitan
+    outerClothing: ClothingOuterArmorNCWLCarapaceKapitan

--- a/_Crescent/Loadouts/Jobs/KapitanNCWL/outer.yml
+++ b/_Crescent/Loadouts/Jobs/KapitanNCWL/outer.yml
@@ -1,9 +1,9 @@
 - type: loadout
-  id: ClothingOuterArmorNCWLCarapaceKapitan
-  equipment: ClothingOuterArmorNCWLCarapaceKapitan
+  id: StartClothingOuterArmorNCWLCarapaceKapitan
+  equipment: StartClothingOuterArmorNCWLCarapaceKapitan
   price: 0
 
 - type: startingGear
-  id: SanitarNCWLClothingUniformJumpsuitNCWL
+  id: StartClothingOuterArmorNCWLCarapaceKapitan
   equipment:
     jumpsuit: ClothingOuterArmorNCWLCarapaceKapitan

--- a/_Crescent/Loadouts/Jobs/Kommisar/bags.yml
+++ b/_Crescent/Loadouts/Jobs/Kommisar/bags.yml
@@ -1,0 +1,9 @@
+ type: loadout
+  id: KommissarClothingBackpackSatchelLeatherFilledNCWL
+  equipment: KommissarClothingBackpackSatchelLeatherFilledNCWL
+  price: 0
+
+- type: startingGear
+  id: KommissarClothingBackpackSatchelLeatherFilledNCWL
+  equipment:
+    back: ClothingBackpackSatchelLeatherFilledNCWL

--- a/_Crescent/Loadouts/Jobs/Kommisar/head.yml
+++ b/_Crescent/Loadouts/Jobs/Kommisar/head.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: KommissarClothingHeadHatNCWLBeret
+  equipment: KomissarClothingHeadHatNCWLBeret
+  price: 0
+
+- type: startingGear
+  id: KommissarClothingHeadHatNCWLBeret
+  equipment:
+    jumpsuit: ClothingHeadHatNCWLKommissarHat

--- a/_Crescent/Loadouts/Jobs/Kommisar/head.yml
+++ b/_Crescent/Loadouts/Jobs/Kommisar/head.yml
@@ -6,4 +6,4 @@
 - type: startingGear
   id: KommissarClothingHeadHatNCWLBeret
   equipment:
-    jumpsuit: ClothingHeadHatNCWLKommissarHat
+    head: ClothingHeadHatNCWLKommissarHat

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/administrator_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/administrator_loadout_groups.yml
@@ -1,0 +1,8 @@
+  - type: loadoutGroup
+  id: SanitarHeadAdministrator
+  name: loadout-group-contractor-head
+  minLimit: 1
+  loadouts:
+  - AdminClothingHeadHatNCWLBeret
+  - SanitarNCWLClothingHeadHelmetNCWLBasic
+  - SanitarNCWLClothingHeadHelmetNCWLHeavy

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/doktor_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/doktor_loadout_groups.yml
@@ -1,17 +1,8 @@
-- type: loadoutGroup
-  id: NCWLOuterClothingKapitan
-  name: loadout-group-contractor-outerclothing
-  minLimit: 1
-  loadouts:
-  - StartClothingOuterArmorNCWLCarapaceKapitan
-  - SanitarNCWLClothingOuterArmorBulletproof
-  - SanitarNCWLClothingOuterArmorNCWLHeavyCarapace
-
   - type: loadoutGroup
-  id: SanitarHeadKapitan
+  id: SanitarHeadDoktor
   name: loadout-group-contractor-head
   minLimit: 1
   loadouts:
-  - KapitanClothingHeadHatNCWLBeret
+  - DoktorClothingHeadHatNCWLCapsoftMedical
   - SanitarNCWLClothingHeadHelmetNCWLBasic
   - SanitarNCWLClothingHeadHelmetNCWLHeavy

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/doktor_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/doktor_loadout_groups.yml
@@ -1,0 +1,17 @@
+- type: loadoutGroup
+  id: NCWLOuterClothingKapitan
+  name: loadout-group-contractor-outerclothing
+  minLimit: 1
+  loadouts:
+  - StartClothingOuterArmorNCWLCarapaceKapitan
+  - SanitarNCWLClothingOuterArmorBulletproof
+  - SanitarNCWLClothingOuterArmorNCWLHeavyCarapace
+
+  - type: loadoutGroup
+  id: SanitarHeadKapitan
+  name: loadout-group-contractor-head
+  minLimit: 1
+  loadouts:
+  - KapitanClothingHeadHatNCWLBeret
+  - SanitarNCWLClothingHeadHelmetNCWLBasic
+  - SanitarNCWLClothingHeadHelmetNCWLHeavy

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/kapitan_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/kapitan_loadout_groups.yml
@@ -1,0 +1,17 @@
+- type: loadoutGroup
+  id: NCWLOuterClothingKapitan
+  name: loadout-group-contractor-outerclothing
+  minLimit: 1
+  loadouts:
+  - //ARMORED JACKET
+  - SanitarNCWLClothingOuterArmorBulletproof
+  - SanitarNCWLClothingOuterArmorNCWLHeavyCarapace
+
+  - type: loadoutGroup
+  id: SanitarHeadKapitan
+  name: loadout-group-contractor-head
+  minLimit: 0
+  loadouts:
+  - //KAPITAN HAT
+  - SanitarNCWLClothingHeadHelmetNCWLBasic
+  - SanitarNCWLClothingHeadHelmetNCWLHeavy

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/kapitan_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/kapitan_loadout_groups.yml
@@ -10,7 +10,7 @@
   - type: loadoutGroup
   id: SanitarHeadKapitan
   name: loadout-group-contractor-head
-  minLimit: 0
+  minLimit: 1
   loadouts:
   - KapitanClothingHeadHatNCWLBeret
   - SanitarNCWLClothingHeadHelmetNCWLBasic

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/kapitan_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/kapitan_loadout_groups.yml
@@ -3,7 +3,7 @@
   name: loadout-group-contractor-outerclothing
   minLimit: 1
   loadouts:
-  - //ARMORED JACKET
+  - StartClothingOuterArmorNCWLCarapaceKapitan
   - SanitarNCWLClothingOuterArmorBulletproof
   - SanitarNCWLClothingOuterArmorNCWLHeavyCarapace
 
@@ -12,6 +12,6 @@
   name: loadout-group-contractor-head
   minLimit: 0
   loadouts:
-  - //KAPITAN HAT
+  - KapitanClothingHeadHatNCWLBeret
   - SanitarNCWLClothingHeadHelmetNCWLBasic
   - SanitarNCWLClothingHeadHelmetNCWLHeavy

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/kommissar_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/kommissar_loadout_groups.yml
@@ -1,0 +1,17 @@
+- type: loadoutGroup
+  id: SanitarHeadKommissar
+  name: loadout-group-contractor-head
+  minLimit: 1
+  loadouts:
+  - KommissarClothingHeadHatNCWLBeret
+  - SanitarNCWLClothingHeadHelmetNCWLBasic
+  - SanitarNCWLClothingHeadHelmetNCWLHeavy
+
+  - type: loadoutGroup
+  id: SanitarBackpack
+  name: loadout-group-contractor-backpack
+  loadouts:
+  - KommissarClothingBackpackSatchelLeatherFilledNCWL
+  - SanitarNCWLClothingBackpackNCWLFilledSanitar
+  - SanitarNCWLClothingBackpackDuffelNCWLFilledSanitar
+  - SanitarNCWLClothingBackpackSatchelNCWLFilledSanitar

--- a/_Crescent/Loadouts/LoadoutGroups/Shared/contractor_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/Shared/contractor_loadout_groups.yml
@@ -573,6 +573,7 @@
   id: ContractorGlasses
   name: loadout-group-contractor-glasses
   minLimit: 0
+  maxLimit: 1
   loadouts:
   - ContractorClothingEyesGlasses
   - ContractorClothingEyesGlassesCheapSunglasses

--- a/_Crescent/Loadouts/LoadoutGroups/Shared/medical_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/Shared/medical_loadout_groups.yml
@@ -1,0 +1,6 @@
+- type: loadoutGroup
+  id: MedicalHypoMini # Right Hand - 1 only
+  name: loadout-group-contractor-utility
+  minLimit: 0
+  loadouts:
+  - ContractorHypoMini

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -50,6 +50,7 @@
   - NCWLOuterClothing
   - SanitarHeadDoktor
   - ContractorGlasses
+  - MedicalHypoMini
   - ContractorTrinkets
 
 # Kapitan
@@ -118,12 +119,14 @@
   id: JobRipperdocNCSP
   groups:
   - ContractorTrinkets
+  - MedicalHypoMini
   - NCSPBackpacks
 
 - type: roleLoadout
   id: JobChemcookNCSP
   groups:
   - ContractorTrinkets
+  - MedicalHypoMini
   - NCSPBackpacks
 
 - type: roleLoadout
@@ -210,6 +213,7 @@
   id: JobSurgeonDSM
   groups:
   - ContractorTrinkets
+  - MedicalHypoMini
   - DSMCommonerBags
 
 - type: roleLoadout
@@ -255,6 +259,7 @@
   id: JobTenderSRM
   groups:
   - ContractorTrinkets
+  - MedicalHypoMini
   - SRMBackpacks
 
 - type: roleLoadout
@@ -317,6 +322,7 @@
   id: JobMedtechSHI
   groups:
   - ContractorTrinkets
+  - MedicalHypoMini
   - SHIBackpacks
 
 #CMM
@@ -337,6 +343,7 @@
   id: JobPhysicianCMM
   groups:
   - ContractorTrinkets
+  - MedicalHypoMini
   - CMMBackpacks
 
 - type: roleLoadout

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -43,6 +43,13 @@
 - type: roleLoadout
   id: JobKapitanNCWL
   groups:
+  - SanitarJumpsuit
+  - SanitarBackpack
+  - NCWLShoes
+  - NCWLOuterClothingKapitan
+  - SanitarHeadKapitan
+  - SanitarBelt
+  - NCWLGloves
   - ContractorTrinkets
 
 # Administrator

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -10,7 +10,9 @@
   - SanitarHead
   - SanitarBelt
   - NCWLGloves
+  - ContractorGlasses
   - ContractorTrinkets
+  
 
 # Kadet
 
@@ -22,6 +24,7 @@
   - NCWLShoes
   - KadetHead
   - KadetBelt
+  - ContractorGlasses
   - ContractorTrinkets
 
 # Kommissar
@@ -34,6 +37,7 @@
   - NCWLOuterClothingKapitan
   - SanitarHeadKommissar
   - NCWLGloves
+  - ContractorGlasses
   - ContractorTrinkets
 
 # Doktor
@@ -45,6 +49,7 @@
   - NCWLShoes
   - NCWLOuterClothing
   - SanitarHeadDoktor
+  - ContractorGlasses
   - ContractorTrinkets
 
 # Kapitan
@@ -57,6 +62,7 @@
   - NCWLOuterClothingKapitan
   - SanitarHeadKapitan
   - NCWLGloves
+  - ContractorGlasses
   - ContractorTrinkets
 
 # Administrator
@@ -68,6 +74,7 @@
   - NCWLOuterClothingKapitan
   - SanitarHeadAdministrator
   - NCWLGloves
+  - ContractorGlasses
   - ContractorTrinkets
 
 # Artificer
@@ -79,6 +86,7 @@
   - NCWLOuterClothing
   - SanitarHeadKapitan
   - NCWLGloves
+  - ContractorGlasses
   - ContractorTrinkets
 #---------------------------#
 

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -41,6 +41,10 @@
 - type: roleLoadout
   id: JobDoktorNCWL
   groups:
+  - SanitarBackpack
+  - NCWLShoes
+  - NCWLOuterClothing
+  - SanitarHeadDoktor
   - ContractorTrinkets
 
 # Kapitan
@@ -60,6 +64,10 @@
 - type: roleLoadout
   id: JobAdministratorNCWL
   groups:
+  - NCWLShoes
+  - NCWLOuterClothingKapitan
+  - SanitarHeadAdministrator
+  - NCWLGloves
   - ContractorTrinkets
 
 # Artificer
@@ -67,8 +75,11 @@
 - type: roleLoadout
   id: JobArtificerNCWL
   groups:
+  - NCWLShoes
+  - NCWLOuterClothing
+  - SanitarHeadKapitan
+  - NCWLGloves
   - ContractorTrinkets
-
 #---------------------------#
 
 #Syndicate

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -29,6 +29,11 @@
 - type: roleLoadout
   id: JobKommissarNCWL
   groups:
+  - SanitarBackpackKommissar
+  - NCWLShoes
+  - NCWLOuterClothingKapitan
+  - SanitarHeadKommissar
+  - NCWLGloves
   - ContractorTrinkets
 
 # Doktor
@@ -43,12 +48,10 @@
 - type: roleLoadout
   id: JobKapitanNCWL
   groups:
-  - SanitarJumpsuit
   - SanitarBackpack
   - NCWLShoes
   - NCWLOuterClothingKapitan
   - SanitarHeadKapitan
-  - SanitarBelt
   - NCWLGloves
   - ContractorTrinkets
 

--- a/_Crescent/Roles/Jobs/NCWL/administrator.yml
+++ b/_Crescent/Roles/Jobs/NCWL/administrator.yml
@@ -70,8 +70,6 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitNCWLCommunications
     back: ClothingBackpackSatchelLeatherFilledNCWLAdministrator
-    shoes: ClothingShoesBootsLaceup
-    head: ClothingHeadHatNCWLBeretAdmiral
     id: AdministratorPDA
     neck: ClothingNeckAdminCapelet
     ears: ClothingHeadsetNCWL

--- a/_Crescent/Roles/Jobs/NCWL/artificer.yml
+++ b/_Crescent/Roles/Jobs/NCWL/artificer.yml
@@ -30,13 +30,10 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitNCWLArtificer
     back: ClothingBackpackDuffelNCWLFilledArtificer
-    shoes: ClothingShoesBootsCombat
-    head: ClothingHeadHatNCWLBeret
     id: ArtificerPDA
     ears: ClothingHeadsetNCWL
     belt: ClothingBeltUtilityEngineering
     pocket1: WeaponPistolHKUSP
     pocket2: NCWLPassportAccepted
-    gloves: ClothingHandsGlovesFingerless
   # duffelbag: ClothingBackpackDuffelNCWLFilledArtificer YAMLFIX: This doesn't go here anymore.
   # satchel: ClothingBackpackSatchelNCWLFilledArtificer

--- a/_Crescent/Roles/Jobs/NCWL/doktor.yml
+++ b/_Crescent/Roles/Jobs/NCWL/doktor.yml
@@ -33,9 +33,7 @@
   id: DoktorGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitNCWLMedic
-    back: ClothingBackpackDuffelNCWLFilledSanitar
     shoes: ClothingShoesColorBlack
-    head: ClothingHeadHatNCWLCapsoftMedical
     id: DoktorPDA
     ears: ClothingHeadsetNCWL
     belt: ClothingBeltMedicalFilled

--- a/_Crescent/Roles/Jobs/NCWL/kapitan.yml
+++ b/_Crescent/Roles/Jobs/NCWL/kapitan.yml
@@ -36,15 +36,10 @@
   id: KapitanGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitNCWL
-    back: ClothingBackpackNCWLFilledSanitar
-    shoes: ClothingShoesBootsCombat
-    head: ClothingHeadHatNCWLBeret
-    outerClothing: ClothingOuterArmorNCWLCarapaceKapitan
     id: KapitanPDA
     ears: ClothingHeadsetNCWL
     belt: ClothingBeltNCWLWebbing
     pocket1: WeaponPistolHKUSP
     pocket2: NCWLPassportAccepted
-    gloves: ClothingHandsGlovesFingerless
   # duffelbag: ClothingBackpackDuffelNCWLFilledSanitar YAMLFIX: This doesn't go here anymore.
   # satchel: ClothingBackpackSatchelNCWLFilledSanitar

--- a/_Crescent/Roles/Jobs/NCWL/kommissar.yml
+++ b/_Crescent/Roles/Jobs/NCWL/kommissar.yml
@@ -71,11 +71,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitNCWLKommissar
     back: ClothingBackpackSatchelLeatherFilledNCWL
-    shoes: ClothingShoesBootsJack
-    head: ClothingHeadHatNCWLKommissarHat
-    outerClothing: ClothingOuterArmorNCWLCarapace
     id: KommissarPDA
     ears: ClothingHeadsetNCWL
     belt: WeaponPistolHKUSP
     pocket1: NCWLPassportAccepted
-    gloves: ClothingHandsGlovesFingerless


### PR DESCRIPTION
Adds NCWL Loadouts for ALL NCWL roles
Every role can choose their backpacks, shoes and gloves (besides Artificer and Doktor who have different starting gear coded in their duffels)

Partisans+ can opt to get Bulletproof Vest/Carapce and their respective helmets instead of their usual berets/armored jackets
(Partisans could already do that, so why not the higher ranks?)

Lets medical roles from all factions get a mini hypo spray (5u/2s cd one) from their loadouts, while also making it cost 2,5k instead of the previous 5k. (syringes are 100 and are more or less the same with the tradeoff for hypos being their slow injection rate in u/s), also adds them to Medical Vendors