### PR TITLE
Shi upcycler + shipment fab fixes

### DIFF
--- a/_Crescent/Entities/Recipes/Lathes/crates.yml
+++ b/_Crescent/Entities/Recipes/Lathes/crates.yml
@@ -67,4 +67,4 @@
   result: TradeGoodAlloys
   completetime: 2
   materials:
-    RefinedScrapTitanium: 5000
+    RefinedScrapTitanium: 10000

--- a/_Crescent/Entities/Recipes/Lathes/crates.yml
+++ b/_Crescent/Entities/Recipes/Lathes/crates.yml
@@ -67,4 +67,4 @@
   result: TradeGoodAlloys
   completetime: 2
   materials:
-    RefinedScrapTitanium: 30000
+    RefinedScrapTitanium: 5000

--- a/_Crescent/Entities/Recipes/Lathes/scrap.yml
+++ b/_Crescent/Entities/Recipes/Lathes/scrap.yml
@@ -2,48 +2,48 @@
 - type: latheRecipe
   id: SteelScrap
   result: RefinedSteelScrap1
-  completetime: 0.8
+  completetime: 0.25
   materials:
     ScrapSteel: 500
 
 - type: latheRecipe
   id: TitaniumScrap
   result: RefinedTitaniumScrap1
-  completetime: 0.8
+  completetime: 0.25
   materials:
     ScrapTitanium: 500
 
 - type: latheRecipe
   id: Garbage
   result: RefinedGarbageOre1
-  completetime: 0.8
+  completetime: 0.25
   materials:
     Garbage: 500
 
 - type: latheRecipe
   id: SteelScraptoSteel1
   result: SheetSteel1
-  completetime: 0.8
+  completetime: 0.25
   materials:
     ScrapSteel: 100
 
 - type: latheRecipe
   id: SteelScraptoSteel
   result: SheetSteel
-  completetime: 0.8
+  completetime: 0.25
   materials:
     ScrapSteel: 3000
 
 - type: latheRecipe
   id: PlasteelFromScrap1
   result: SheetPlasteel1
-  completetime: 0.8
+  completetime: 0.25
   materials:
     ScrapTitanium: 200
 
 - type: latheRecipe
   id: PlasteelFromScrap
   result: SheetPlasteel
-  completetime: 0.8
+  completetime: 0.25
   materials:
     ScrapTitanium: 6000


### PR DESCRIPTION
Shifts the refined Scraptitan shipment final requirement to the likes of that required for the classic scrap shipments. 
Makes no sense for it to 'require more' than scrapsteel, since it's a more valuable basic commodity.

Compensates the 50% speed debuff (was 1.6 seconds in practice) to 0.5 seconds, since refining's mostly done in large quantities.
