### PR TITLE
PICK ONE - Removes Vibro from DSM Research

### DIFF
--- a/_Crescent/Research/imperial.yml
+++ b/_Crescent/Research/imperial.yml
@@ -174,15 +174,3 @@
   cost: 12500
   recipeUnlocks:
   - DSMPlasmaTurretFlatpackCraft
-
-- type: technology
-  id: ImperialSword
-  name: research-technology-impkhopesh
-  icon:
-    sprite: _Crescent/Objects/Weapons/vibrokhopesh.rsi
-    state: icon
-  discipline: Imperial
-  tier: 3
-  cost: 20000
-  recipeUnlocks:
-  - SRMKhopeshCraft


### PR DESCRIPTION
As title.

**Why is this good?**

No more accessible 75% deflect weapons that can be onehanded with a gun in your other active hand, reflecting shots while you also fire your own. This makes fights less reliant on having an 'I win' weapon and more reliant on actually fighting. This was originally intended for SRM as the Super Special Faction and I don't think this has any place in 'regular' rounds, outside of admin interference. Regardless of when CSA are getting implemented, it's maybe not a particularly good thing to have in almost every recent round.