### PR TITLE
PICK ONE - Vibrokhopesh Nerfs

### DIFF
--- a/_Crescent/Entities/Objects/Weapons/special.yml
+++ b/_Crescent/Entities/Objects/Weapons/special.yml
@@ -267,3 +267,34 @@
   - type: Item
     size: Normal
   - type: DisarmMalus #harder to shake firm grip
+
+- type: entity
+  name: divine curveblade
+  parent: BaseItem
+  id: DSMKhopesh
+  description: A deadly arc of a weapon, reminiscent of the cradle of humanity's only sun.
+  components:
+  - type: Sharp
+  - type: Sprite
+    sprite: _Crescent/Objects/Weapons/vibrokhopesh.rsi
+    state: icon
+  - type: MeleeWeapon
+    wideAnimationRotation: -135
+    attackRate: 1.5
+    damage:
+      types:
+        Slash: 30
+        Heat: 10
+    soundHit:
+        path: /Audio/Weapons/bladeslice.ogg
+  - type: Reflect
+    enabled: true
+    reflectProb: .30
+    spread: 75
+  - type: Item
+    size: Normal
+    sprite: _Crescent/Objects/Weapons/vibrokhopesh.rsi
+  - type: Tag
+    tags:
+    - Khopesh
+  - type: DisarmMalus

--- a/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
+++ b/_Crescent/Entities/Recipes/Lathes/imperialcrafts.yml
@@ -192,11 +192,11 @@
     Plastic: 500
 
 - type: latheRecipe
-  id: SRMKhopeshCraft
-  result: SRMKhopesh
+  id: DSMKhopeshCraft
+  result: DSMKhopesh
   completetime: 4
   materials:
     Steel: 1000
-    Silver: 2500
+    Silver: 2000
     Plasma: 1000
     # Diamond: 500 YAMLFIX: Diamond isn't a material prototype sweaty

--- a/_Crescent/Entities/Structures/lathe.yml
+++ b/_Crescent/Entities/Structures/lathe.yml
@@ -478,7 +478,7 @@
       - ClothingHeadHelmetImperialTrooperHelmetCraft
       - ClothingHeadHelmetImperialKnightCommanderHelmetCraft
       - DSMPlasmaTurretFlatpackCraft
-      - SRMKhopeshCraft
+      - DSMKhopeshCraft
       - SHIFighterThrusterFlatpackCraft
       - SHIWarshipThrusterFlatpackCraft
       - WeaponPistolBlastpopGrayCraft

--- a/_Crescent/Research/imperial.yml
+++ b/_Crescent/Research/imperial.yml
@@ -185,4 +185,4 @@
   tier: 3
   cost: 20000
   recipeUnlocks:
-  - SRMKhopeshCraft
+  - DSMKhopeshCraft

--- a/_Crescent/Research/techdisks.yml
+++ b/_Crescent/Research/techdisks.yml
@@ -253,7 +253,7 @@
   parent: BaseItem
   id: ImperialFabdiskKhopesh
   name: imperial fabdisk
-  description: A disk for the R&D server containing research technology. A label reads, 'OLYWIR FOUNDRY - VIBROBLADE'.
+  description: A disk for the R&D server containing research technology. A label reads, 'OLYWIR FOUNDRY - CURVEBLADE'.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/Misc/techdisks.rsi
@@ -261,7 +261,7 @@
     - state: iconnanotrasen
   - type: TechnologyDisk
     recipes:
-      - SRMKhopeshCraft
+      - DSMKhopeshCraft
   - type: StaticPrice
     price: 12500
 


### PR DESCRIPTION
As title.

Creates a new entry for the khopesh, named the divine curveblade. Changes salvage techdisk/lathe recipe/research entry/other references previously for the SRM Vibrokhopesh to this. Drops the deflect chance to 0.3 from 0.75, drops the silver cost to 2000 from 2500. Drops slash damage to 30, adds 10 heat damage.

**Why is this good for the game?**

Keeps the original SRM Vibro separate and untouched for admin use. DSM players won't cry as much. Can be easily used as a CSA piece post-switchover with a little rename of the ID and such.