### PR TITLE
Shiver Blade changes

### DIFF
--- a/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Entities/Objects/Weapons/Melee/sword.yml
@@ -90,7 +90,7 @@
   - type: Prying
     pryPowered: true
   - type: Tool
-    speed: 0.1
+    speed: 1
     qualities:
       - Prying
     useSound:

--- a/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Entities/Objects/Weapons/Melee/sword.yml
@@ -81,18 +81,22 @@
     size: Large
     sprite: Objects/Weapons/Melee/energykatana.rsi
   - type: EnergyKatana
-  - type: DashAbility
-  - type: LimitedCharges
-    maxCharges: 3
-    charges: 3
-  - type: AutoRecharge
-    rechargeDuration: 20
   - type: Clothing
     sprite: Objects/Weapons/Melee/energykatana.rsi
     slots:
     - Back
-    - Belt
+    - Belt  
   - type: Reflect
+  - type: Prying
+    pryPowered: true
+    SpeedModifier: 0.1
+  - type: Tool
+    speed: 0.1
+    qualities:
+      - Prying
+    useSound:
+      path: /Audio/Items/jaws_pry.ogg
+
 
 - type: entity
   name: machete

--- a/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Entities/Objects/Weapons/Melee/sword.yml
@@ -89,7 +89,6 @@
   - type: Reflect
   - type: Prying
     pryPowered: true
-    SpeedModifier: 0.1
   - type: Tool
     speed: 0.1
     qualities:


### PR DESCRIPTION
Shiver Blade is it is, feels severely underpowered
It feels like a machette reskin..

This PR allows it to pry open doors at 1/10th the speed to keep it balanced. There is only one such sword on the whole map and it used to be a SHI T3 weapon, so it makes no sense for it to be treated as a reskin weapon by everyone (and I mean it, I've seen it several times, where people chatted about who should get it from a fallen guy and not many even bothered speaking up for it)

Also, removes the charges system which wasn't used anyways due to energy dash skill requiring You to be a space ninja

IMPORTANT: I'VE DONE BOTH speed IN TOOL COMPONENT AND SpeedModifier IN PRYING COMPONENT BECAUSE I AM NOT SURE WHICH ONE SHOULD I USE AS I HAVE NO ACCESS TO COMPONENTS (Same reason why I didn't make it so that the blade can do the prying using charges, which I think would be the best option. 3 charges, 60s cooldown on recharge and it lets the blade open doors, instead I made it REALLY slow) SO I NEED SOMEONE TO HELP ME OUT WITH THIS ONE, I WILL MAKE AN ADDITIONAL COMMIT THEN