### PR TITLE
NCWL Loadouts Fixes

### DIFF
--- a/_Crescent/Loadouts/Jobs/AdmiralNCWL/outer.yml
+++ b/_Crescent/Loadouts/Jobs/AdmiralNCWL/outer.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: AdminNCWLCoat
+  equipment: AdminNCWLCoat
+  price: 0
+
+- type: startingGear
+  id: AdminNCWLCoat
+  equipment:
+    outerClothing: ClothingOuterArmorNCWLOpremeCarapace

--- a/_Crescent/Loadouts/Jobs/Kommisar/outer.yml
+++ b/_Crescent/Loadouts/Jobs/Kommisar/outer.yml
@@ -1,0 +1,9 @@
+- type: loadout
+  id: KommissarNCWLCoat
+  equipment: KommissarNCWLCoat
+  price: 0
+
+- type: startingGear
+  id: KommissarNCWLCoat
+  equipment:
+    outerClothing: ClothingOuterArmorNCWLCarapace

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/administrator_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/administrator_loadout_groups.yml
@@ -1,8 +1,13 @@
-#  type: loadoutGroup
-#  id: SanitarHeadAdministrator
-#  name: loadout-group-contractor-head
-#  minLimit: 1
-#  loadouts:
-#  - AdminClothingHeadHatNCWLBeret
-#  - SanitarNCWLClothingHeadHelmetNCWLBasic
-#  - SanitarNCWLClothingHeadHelmetNCWLHeavy
+  type: loadoutGroup
+  id: AdminHatNCWL
+  name: loadout-group-contractor-head
+  minLimit: 1
+  loadouts:
+  - AdminClothingHeadHatNCWLBeret
+
+- type: loadoutGroup
+  id: AdminOuterNCWL
+  name: loadout-group-contractor-outerclothing
+  minLimit: 1
+  loadouts:
+  - AdminNCWLCoat

--- a/_Crescent/Loadouts/LoadoutGroups/NCWL/kommissar_loadout_groups.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/NCWL/kommissar_loadout_groups.yml
@@ -4,3 +4,10 @@
   minLimit: 0
   loadouts:
   - KommissarClothingHeadHatNCWLBeret
+
+  - type: loadoutGroup
+  id: KommissarCoatNCWL
+  name: loadout-group-contractor-outerclothing
+  minLimit: 1
+  loadouts:
+  - KommissarNCWLCoat

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -71,7 +71,8 @@
   id: JobAdministratorNCWL
   groups:
   - NCWLShoes
-  - NCWLOuterClothingKapitan
+  - AdminOuterNCWL
+  - AdminHatNCWL
   - NCWLGloves
   - ContractorGlasses
   - ContractorTrinkets
@@ -83,7 +84,7 @@
   groups:
   - NCWLShoes
   - NCWLOuterClothing
-  - SanitarHeadKapitan
+  - SanitarHead
   - NCWLGloves
   - ContractorGlasses
   - ContractorTrinkets

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -32,6 +32,7 @@
 - type: roleLoadout
   id: JobKommissarNCWL
   groups:
+  - SanitarBackpack
   - NCWLShoes
   - KommissarCoatNCWL
   - SanitarHeadKommissar
@@ -70,6 +71,7 @@
 - type: roleLoadout
   id: JobAdministratorNCWL
   groups:
+  - SanitarBackpack
   - NCWLShoes
   - AdminOuterNCWL
   - AdminHatNCWL

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -33,7 +33,7 @@
   id: JobKommissarNCWL
   groups:
   - NCWLShoes
-  - NCWLOuterClothingKapitan
+  - KommissarCoatNCWL
   - SanitarHeadKommissar
   - NCWLGloves
   - ContractorGlasses

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -84,7 +84,7 @@
   groups:
   - NCWLShoes
   - NCWLOuterClothing
-  - SanitarHead
+  - SanitarHeadKapitan
   - NCWLGloves
   - ContractorGlasses
   - ContractorTrinkets

--- a/_Crescent/Roles/Jobs/NCWL/administrator.yml
+++ b/_Crescent/Roles/Jobs/NCWL/administrator.yml
@@ -69,7 +69,6 @@
   id: AdministratorGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitNCWLCommunications
-    back: ClothingBackpackSatchelLeatherFilledNCWLAdministrator
     id: AdministratorPDA
     neck: ClothingNeckAdminCapelet
     ears: ClothingHeadsetNCWL

--- a/_Crescent/Roles/Jobs/NCWL/administrator.yml
+++ b/_Crescent/Roles/Jobs/NCWL/administrator.yml
@@ -73,5 +73,6 @@
     id: AdministratorPDA
     neck: ClothingNeckAdminCapelet
     ears: ClothingHeadsetNCWL
-    belt: WeaponPistolT91
+    belt: ClothingBeltNCWLWebbing
     pocket1: NCWLPassportAccepted
+    pocket2: WeaponPistolT91

--- a/_Crescent/Roles/Jobs/NCWL/kommissar.yml
+++ b/_Crescent/Roles/Jobs/NCWL/kommissar.yml
@@ -70,7 +70,6 @@
   id: KommissarGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitNCWLKommissar
-    back: ClothingBackpackSatchelLeatherFilledNCWL
     id: KommissarPDA
     ears: ClothingHeadsetNCWL
     belt: WeaponPistolHKUSP


### PR DESCRIPTION
Major Loadouts fixes, this time I've done it correctly
Also makes them spawn with a webbing for quallity of life (they don't have to run around trying to find a spare one, which happens as it is now)

Also Artificers can't start with Kapitan's hat anymore

EDIT: Artificers can in fact start with Officer Hat