### PR TITLE
NCWL Conscript is actually a slugthrower now

### DIFF
--- a/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
+++ b/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
@@ -21,6 +21,10 @@
   - type: Sprite
     sprite: _Crescent/Ammunition/conscript_ammo_box.rsi
     state: base
+  - type: Clothing
+    sprite: _Crescent/Ammunition/conscript_ammo_box.rsi
+    slots:
+    - Belt
 
 #slugs
 

--- a/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
+++ b/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
@@ -6,10 +6,14 @@
   components:
   - type: Tag
     tags:
-      - MagazineLightRifleBox
+      - MagazineNCWLConscriptBox
   - type: BallisticAmmoProvider
-    proto: CartridgeLightRifle
-    capacity: 200
+    mayTransfer: true
+    whitelist:
+      tags:
+        - CartridgeMachineGun
+    proto: CartridgeMachineGunHighExplosive
+    capacity: 75
   - type: Item
   - type: Sprite
     sprite: _Crescent/Ammunition/conscript_ammo_box.rsi

--- a/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
+++ b/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
@@ -16,6 +16,8 @@
     capacity: 75
   - type: Item
     size: Large
+    shape:
+    - 0,0,2,2
   - type: Sprite
     sprite: _Crescent/Ammunition/conscript_ammo_box.rsi
     state: base

--- a/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
+++ b/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
@@ -15,6 +15,7 @@
     proto: CartridgeMachineGunHighExplosive
     capacity: 75
   - type: Item
+    size: Large
   - type: Sprite
     sprite: _Crescent/Ammunition/conscript_ammo_box.rsi
     state: base

--- a/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -14,7 +14,7 @@
     maxAngle: 4
     angleIncrease: 4
     angleDecay: 12
-    fireRate: 3
+    fireRate: 2
     selectedMode: FullAuto
     availableModes:
       - FullAuto

--- a/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -39,7 +39,7 @@
             - MagazineNCWLConscriptBox
       gun_chamber:
         name: Chamber
-        startingItem: MagazineLightRifleBoxSlug
+        startingItem: CartridgeMachineGunHighExplosive
         priority: 1
         whitelist:
           tags:

--- a/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -40,14 +40,14 @@
         priority: 2
         whitelist:
           tags:
-            - MagazineLightRifleBox
+            - MagazineNCWLConscriptBox
       gun_chamber:
         name: Chamber
-        startingItem: CartridgeLightRifle
+        startingItem: MagazineLightRifleBoxSlug
         priority: 1
         whitelist:
           tags:
-            - CartridgeLightRifle
+            - CartridgeMachineGun
   - type: ContainerContainer
     containers:
       gun_magazine: !type:ContainerSlot

--- a/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -14,7 +14,7 @@
     maxAngle: 4
     angleIncrease: 4
     angleDecay: 12
-    fireRate: 4
+    fireRate: 2
     selectedMode: FullAuto
     availableModes:
       - FullAuto

--- a/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -14,7 +14,7 @@
     maxAngle: 4
     angleIncrease: 4
     angleDecay: 12
-    fireRate: 2
+    fireRate: 3
     selectedMode: FullAuto
     availableModes:
       - FullAuto

--- a/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -61,10 +61,10 @@
     malus: -1
 
 - type: entity
-  name: NCWL .30 Conscript
+  name: NCWL .50 Conscript
   id: WeaponLightMachineGunConscript
   parent: BaseWeaponLightMachineGunConscript
-  description: A bulky .30 autocannon, ripped straight from a shuttle turret. You have to be insane to actually use this.
+  description: A bulky .50 autocannon, ripped straight from a shuttle turret. You have to be insane to actually use this.
   components:
   - type: Sprite
     sprite: _Crescent/Objects/Weapons/conscript.rsi

--- a/_Crescent/Entities/Objects/Weapons/lmgs.yml
+++ b/_Crescent/Entities/Objects/Weapons/lmgs.yml
@@ -8,14 +8,10 @@
   - type: Sprite
   - type: Item
     size: Huge
-  - type: Wieldable
-    unwieldOnUse: false
-  - type: GunWieldBonus
-    minAngle: -20
-    maxAngle: -35
+  - type: MultiHandedItem
   - type: Gun
-    minAngle: 24
-    maxAngle: 37
+    minAngle: 2
+    maxAngle: 4
     angleIncrease: 4
     angleDecay: 12
     fireRate: 4


### PR DESCRIPTION
Makes NCWL Conscript actually shoot .50 slugs, magazine is lowered to 75 and made 3x3 (as per MLGs request)
Should be able to take all Slugthrower ammo in a mag, deaults to low yield (copied code from Slugthrower mags)
Also, let's the magazine be kept on belt solt

Also changes the tag to MagazineNCWLConscriptBox or something like that to avoid confusion in the future