### PR TITLE
FIXES CONSCRIPT WALL PHASING

### DIFF
--- a/_Crescent/Entities/Objects/Ammunition/Projectiles/lmg.yml
+++ b/_Crescent/Entities/Objects/Ammunition/Projectiles/lmg.yml
@@ -1,0 +1,34 @@
+#Ammo For Conscript, copied slugthrower one but doesn't phase trough walls
+- type: entity
+  id: BulletMachineGunHighExplosiveConscript
+  name: .50 low-yield explosive Conscript bullet
+  parent: BaseBulletTrigger
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    ignoreWeaponGrid: true
+    damage:
+      types:
+        Structural: 55
+        #currently explosion deals 21 damage per tile in large AoE
+  - type: TimedDespawn
+    lifetime: 10
+    #roughly 600m range
+  - type: Sprite
+    sprite: _NF/Objects/SpaceArtillery/50_highexplosive_machinegun_casing.rsi
+    layers:
+      - state: base-projectile
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 12
+    intensitySlope: 15
+    totalIntensity: 13
+    maxTileBreak: 2
+  - type: PointLight
+    radius: 5
+    color: orange
+    energy: 0.8
+  - type: ProjectileIFF
+
+  

--- a/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
+++ b/_Crescent/Entities/Objects/Ammunition/light_rifle.yml
@@ -1,3 +1,4 @@
+#conscript
 
 - type: entity
   id: MagazineLightRifleBoxConscript
@@ -11,8 +12,8 @@
     mayTransfer: true
     whitelist:
       tags:
-        - CartridgeMachineGun
-    proto: CartridgeMachineGunHighExplosive
+        - CartridgeMachineGunConscript
+    proto: CartridgeMachineGunHighExplosiveConscript
     capacity: 75
   - type: Item
     size: Large
@@ -26,6 +27,30 @@
     slots:
     - Belt
 
+
+- type: entity
+  id: CartridgeMachineGunHighExplosiveConscript
+  name: .50 low-yield explosive Conscript cartridge
+  parent: BaseItem
+  description: An explosive-tipped slugthrower cartridge.
+  components:
+  - type: Tag
+    tags:
+      - CartridgeMachineGunConscript
+      - Cartridge
+  - type: Item
+    size: Tiny
+  - type: CartridgeAmmo
+    proto: BulletMachineGunHighExplosiveConscript
+    deleteOnSpawn: true
+  - type: Sprite
+    sprite: _NF/Objects/SpaceArtillery/50_highexplosive_machinegun_casing.rsi
+    layers:
+    - state: base
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+  - type: SpaceGarbage
 #slugs
 
 


### PR DESCRIPTION
THAT^
Limits the current variety for Conscritp gun to only low yield, will add other types of bullets later on (Gotta need sprites for different mags though)