### PR TITLE
Breaching round change

### DIFF
--- a/_Crescent/Entities/Objects/DonatorShotgun/projectiles.yml
+++ b/_Crescent/Entities/Objects/DonatorShotgun/projectiles.yml
@@ -58,4 +58,4 @@
     damage:
       types:
         Piercing: 20
-        Structural: 100
+        Structural: 500


### PR DESCRIPTION
Currently 4gauge shotguns deal 100 structural damage, airlocks are 500 health, this means you have to fire 4 shots, reload, and fire another shot to breach a door for a total of 5 shots.