### PR TITLE
Rebuff Torpedos

### DIFF
--- a/_Crescent/Entities/Objects/Ammunition/cannonammo.yml
+++ b/_Crescent/Entities/Objects/Ammunition/cannonammo.yml
@@ -417,7 +417,7 @@
     ignoreWeaponGrid: true
     damage:
       types:
-        Structural: 250
+        Structural: 800
         Blunt: 40
   - type: Tag
     tags:


### PR DESCRIPTION
Dotto intended this as a first-strike weapon.

Yes, 5000 is a bit extreme, but 250 structural would literally make it weaker than other weapons.

Instead, address UL spam or make MISSILES AND TORPEDOS collide with OTHER PROJECTILES and have PD lock onto them.