### PR TITLE
Vibrokhopesh is a forced 2-handed item

### DIFF
--- a/_Crescent/Entities/Clothing/SRM/sword.yml
+++ b/_Crescent/Entities/Clothing/SRM/sword.yml
@@ -27,3 +27,4 @@
     tags:
     - Khopesh
   - type: DisarmMalus
+  - type: MultiHandedItem


### PR DESCRIPTION
This forces the vibrokhopesh into being a melee weapon proper, so if you want the 75% reflect and 49.5 DPS wunderwaffle you have to fully commit to a melee weapon instead of off-handing it and using any other gun in your primary hand.