### PR TITLE
Add caliber to Hephaeustus artillery platform

### DIFF
--- a/_Crescent/Entities/Structures/turrets.yml
+++ b/_Crescent/Entities/Structures/turrets.yml
@@ -1704,7 +1704,7 @@
 - type: entity
   parent: BaseStructure
   id: BaseWeaponTurretBattlemortar
-  name: heavy 'Hephaeustus' assault artillery platform
+  name: 230mm 'Hephaeustus' assault artillery platform
   components:
     - type: PointCannon
     - type: Clickable


### PR DESCRIPTION
Renames "heavy 'Hephaeustus' assault artillery platform" to "230mm 'Hephaeustus' assault artillery platform" for consistency with other guns and reduced confusion when procuring ammo.