### PR TITLE
ArmourDamageMultiplier for Slugthrowers

### DIFF
--- a/_Crescent/Entities/Objects/Ammunition/Projectiles/lmg.yml
+++ b/_Crescent/Entities/Objects/Ammunition/Projectiles/lmg.yml
@@ -7,6 +7,11 @@
   components:
   - type: Projectile
     ignoreWeaponGrid: false
+    damage:
+      types:
+        Structural: 55
+        Pierce: 55
+    armorDamageMultiplier: 10
 
 - type: entity
   id: BulletMachineGunArmorPiercingConscript
@@ -16,4 +21,9 @@
   components:
   - type: Projectile
     ignoreWeaponGrid: false
+    damage:
+      types:
+        Structural: 95
+        Pierce: 95
+    armorDamageMultiplier: 10
 

--- a/_Crescent/Entities/Objects/Ammunition/Projectiles/lmg.yml
+++ b/_Crescent/Entities/Objects/Ammunition/Projectiles/lmg.yml
@@ -2,66 +2,18 @@
 - type: entity
   id: BulletMachineGunHighExplosiveConscript
   name: .50 low-yield explosive Conscript bullet
-  parent: BaseBulletTrigger
+  parent: BulletMachineGunHighExplosive
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
     ignoreWeaponGrid: false
-    damage:
-      types:
-        Structural: 55
-        #currently explosion deals 21 damage per tile in large AoE
-  - type: TimedDespawn
-    lifetime: 10
-    #roughly 600m range
-  - type: Sprite
-    sprite: _NF/Objects/SpaceArtillery/50_highexplosive_machinegun_casing.rsi
-    layers:
-      - state: base-projectile
-  - type: ExplodeOnTrigger
-  - type: Explosive
-    explosionType: Default
-    maxIntensity: 12
-    intensitySlope: 15
-    totalIntensity: 13
-    maxTileBreak: 2
-  - type: PointLight
-    radius: 5
-    color: orange
-    energy: 0.8
-  - type: ShipWeaponProjectile
-  - type: ProjectileIFF
 
 - type: entity
   id: BulletMachineGunArmorPiercingConscript
   name: .50 AP Conscript bullet
-  parent: BaseBulletTrigger
+  parent: BulletMachineGunArmorPiercing
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
     ignoreWeaponGrid: false
-    damage:
-      types:
-        Structural: 95
-        #currently explosion deals 30 damage
-  - type: TimedDespawn
-    lifetime: 10
-    #roughly 600m range
-  - type: Sprite
-    sprite: _NF/Objects/SpaceArtillery/50_armorpiercing_machinegun_casing.rsi
-    layers:
-      - state: base-projectile
-  - type: ExplodeOnTrigger
-  - type: Explosive
-    explosionType: Default
-    maxIntensity: 9
-    intensitySlope: 7
-    totalIntensity: 7
-    maxTileBreak: 1
-  - type: PointLight
-    radius: 3.5
-    color: orange
-    energy: 0.5
-  - type: ShipWeaponProjectile
-  - type: ProjectileIFF
 

--- a/_Crescent/Entities/SpaceArtillery/shells.yml
+++ b/_Crescent/Entities/SpaceArtillery/shells.yml
@@ -189,6 +189,7 @@
       types:
         Structural: 35
         Blunt: 10
+    armorDamageMultiplier: 10
   - type: TimedDespawn
     lifetime: 10
     #roughly 600m range
@@ -243,6 +244,7 @@
       types:
         Structural: 95
         #currently explosion deals 30 damage
+    armorDamageMultiplier: 10
   - type: TimedDespawn
     lifetime: 10
     #roughly 600m range
@@ -301,6 +303,7 @@
       types:
         Structural: 55
         #currently explosion deals 21 damage per tile in large AoE
+    armorDamageMultiplier: 10
   - type: TimedDespawn
     lifetime: 10
     #roughly 600m range

--- a/_Crescent/Entities/SpaceArtillery/shells.yml
+++ b/_Crescent/Entities/SpaceArtillery/shells.yml
@@ -73,7 +73,6 @@
       types:
         Structural: 150
         #currently explosion deals roughly 30 damage per tile in large AoE
-    armorDamageMultiplier: 10
   - type: TimedDespawn
     lifetime: 240
     #roughly 22800m range
@@ -131,7 +130,6 @@
       types:
         Structural: 1
         #currently explosion deals roughly 30 damage per tile in large AoE
-    armorDamageMultiplier: 10
   - type: TimedDespawn
     lifetime: 240
     #roughly 22800m range

--- a/_Crescent/Entities/SpaceArtillery/shells.yml
+++ b/_Crescent/Entities/SpaceArtillery/shells.yml
@@ -73,6 +73,7 @@
       types:
         Structural: 150
         #currently explosion deals roughly 30 damage per tile in large AoE
+    armorDamageMultiplier: 10
   - type: TimedDespawn
     lifetime: 240
     #roughly 22800m range
@@ -130,6 +131,7 @@
       types:
         Structural: 1
         #currently explosion deals roughly 30 damage per tile in large AoE
+    armorDamageMultiplier: 10
   - type: TimedDespawn
     lifetime: 240
     #roughly 22800m range


### PR DESCRIPTION
x10 ArmourDamageMultiplier for Slugthrowers
And also makes Conscript ammo a child of slugthrower ammo (1:1 except they don't phase trough your grid)