### PR TITLE
Olywir fixes the outdated lightbulb in the Advocatus' helmet and Isobel learns how to toggles the power on and off on the old CRN helmets.

### DIFF
--- a/_Crescent/Entities/Clothing/Empire/Head/hardsuit-helmets.yml
+++ b/_Crescent/Entities/Clothing/Empire/Head/hardsuit-helmets.yml
@@ -42,7 +42,7 @@
     sprite: _Crescent/Clothing/Empire/Head/inspector.rsi
   - type: PointLight
     radius: 6
-    color: "#182d09"
+    color: "#184b0a"
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
@@ -72,7 +72,7 @@
     sprite: _Crescent/Clothing/Empire/Head/clarizianworker.rsi
   - type: PointLight
     radius: 6
-    color: "#182d09"
+    color: "#c3fffa"
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
@@ -103,7 +103,7 @@
     sprite: _Crescent/Clothing/Empire/Head/clarizian.rsi
   - type: PointLight
     radius: 6
-    color: "#182d09"
+    color: "#c3fffa"
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000


### PR DESCRIPTION
the dark green used barely gives any lighting for the Advocatus' helmet so i turned up the brightness of it

CRN helmets now use a bright pastel cyan light