### PR TITLE
The Specialists update (Disarm long weapons rework)

### DIFF
--- a/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -65,8 +65,6 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
-  - type: DisarmMalus
-    malus: -1
 
 - type: entity
   name: PTA HJKE-11 Viper 9x19mm

--- a/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -49,8 +49,6 @@
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
   - type: StaticPrice
     price: 50
-  - type: DisarmMalus
-    malus: -1
 
 - type: entity
   name: NT LEQ-023 Deckard .327

--- a/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -52,7 +52,7 @@
   - type: StaticPrice
     price: 500
   - type: DisarmMalus
-    malus: -0.2
+    malus: -1
 
 - type: entity
   name: NCSP AKMS-47 7.62x51mm

--- a/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -55,7 +55,7 @@
   - type: StaticPrice
     price: 750
   - type: DisarmMalus
-    malus: -1
+    malus: -.5
 
 - type: entity
   name: NCSP Atreides 9x19mm

--- a/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -44,6 +44,8 @@
         ents: []
   - type: StaticPrice
     price: 500
+  - type: DisarmMalus
+    malus: -1
 
 - type: entity
   name: PTA MOD-2 Pozhar 12g
@@ -103,8 +105,6 @@
   - type: StaticPrice
     price: 750
   - type: Contraband #frontier
-  - type: DisarmMalus
-    malus: -1
 
 - type: entity
   name: double-barreled shotgun

--- a/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -37,6 +37,8 @@
         ents: []
   - type: StaticPrice
     price: 500
+  - type: DisarmMalus
+    malus: -1
 
 - type: entity # Frontier - Mosin rework (PR#1391)
   name: ICM Kardashev-Mosin 7.62x51mm
@@ -89,8 +91,6 @@
     - back
     - suitStorage
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
-  - type: DisarmMalus
-    malus: 0.225 # End Frontier
 
 
 - type: entity


### PR DESCRIPTION
All long weapons now have 100% disarm, SMGs have 50% disarm, pistols can be disarmed as any other object in ss14, ie default disarm, no malus.