### PR TITLE
Increase Borg health, allow self repair.

### DIFF
--- a/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -45,8 +45,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Critical
-      200: Dead
+      300: Critical
+      600: Dead
     stateAlertDict:
       Alive: BorgHealth
       Critical: BorgCrit
@@ -97,7 +97,7 @@
     - Science
   - type: Repairable
     doAfterDelay: 10
-    allowSelfRepair: false
+    allowSelfRepair: true
   - type: BorgChassis
   - type: WiresPanel
   - type: ActivatableUIRequiresPanel
@@ -152,7 +152,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 75
+        damage: 200
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -161,7 +161,7 @@
             volume: 5
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 750
       behaviors:
       - !type:PlaySoundBehavior
         sound:


### PR DESCRIPTION
Increases borg crit stat from 100 (dead in 6 shots) to 300 (capable of fighting and taking quite a few hits

Increases borg dead stat from 200 (literally 15 bullets) to 600, making it much better to capture them than kill

Increased destruction threshold to 750, meaning it takes longer before they destroy via damage (previously 300)

Also changed the sound cues around a little. so that it lines up with when the borg goes crit and such.