### PR TITLE
Buff TFSC research

### DIFF
--- a/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -36,8 +36,8 @@
         variation: 0.125
     activatedDamage:
         types:
-            Slash: 17
-            Heat: 20
+            Slash: 20
+            Heat: 25
             Structural: 20
   - type: Sprite
     sprite: Objects/Weapons/Melee/e_sword.rsi

--- a/_Crescent/Entities/Objects/Devices/flatpack.yml
+++ b/_Crescent/Entities/Objects/Devices/flatpack.yml
@@ -431,6 +431,34 @@
     - state: ame-part
   - type: StaticPrice
     price: 15000
+
+- type: entity
+  parent: BaseFlatpack
+  id: FlakCannonTurretFlatpack
+  name: Prince flak artillery flatpack
+  description: A flatpack used for constructing artillery cannons with a universal commercial IFF.
+  components:
+  - type: Flatpack
+    entity: FlakCannonTurret
+  - type: Sprite
+    layers:
+    - state: ame-part
+  - type: StaticPrice
+    price: 10000
+
+- type: entity
+  parent: BaseFlatpack
+  id: BaseWeaponTurretGargoyleFlatpack
+  name: Gargoyle missile platform flatpack
+  description: A flatpack used for constructing artillery cannons with a universal commercial IFF.
+  components:
+  - type: Flatpack
+    entity: BaseWeaponTurretGargoyle
+  - type: Sprite
+    layers:
+    - state: ame-part
+  - type: StaticPrice
+    price: 12500
     
 - type: entity
   parent: BaseFlatpack

--- a/_Crescent/Entities/Recipes/Lathes/piratecrafts.yml
+++ b/_Crescent/Entities/Recipes/Lathes/piratecrafts.yml
@@ -9,7 +9,7 @@
     Cloth: 1000
 
 - type: latheRecipe
-  id: ClothingOuterHardsuitCybersunNCSP #TBD
+  id: ClothingOuterHardsuitCybersunNCSP
   result: ClothingOuterHardsuitCybersun
   completetime: 4
   materials:
@@ -18,7 +18,7 @@
     Cloth: 1000
 
 - type: latheRecipe
-  id: ClothingOuterHardsuitTraumasecNCSP #TBD
+  id: ClothingOuterHardsuitTraumasecNCSP
   result: ClothingOuterHardsuitTraumasec
   completetime: 4
   materials:
@@ -159,7 +159,7 @@
     Plasma: 250
 
 - type: latheRecipe
-  id: FlakCannonTurretFlatpackCraftNCSP #TBD
+  id: FlakCannonTurretFlatpackCraftNCSP
   result: FlakCannonTurretFlatpack
   completetime: 4
   materials:
@@ -168,7 +168,7 @@
     Plasma: 1000
 
 - type: latheRecipe
-  id: BaseWeaponTurretGargoyleFlatpackCraftNCSP #TBD
+  id: BaseWeaponTurretGargoyleFlatpackCraftNCSP
   result: BaseWeaponTurretGargoyleFlatpack
   completetime: 4
   materials:
@@ -177,7 +177,7 @@
     Plasma: 1500
 
 - type: latheRecipe
-  id: EnergyShieldNCSP #TBD
+  id: EnergyShieldNCSP
   result: EnergyShield
   completetime: 4
   materials:
@@ -187,7 +187,7 @@
     Plasma: 1500
 
 - type: latheRecipe
-  id: EnergySwordNCSP #TBD
+  id: EnergySwordNCSP
   result: EnergySword
   completetime: 4
   materials:
@@ -213,7 +213,7 @@
     Plastic: 1750
 
 - type: latheRecipe
-  id: WeaponRifleBarghestNCSP #TBD
+  id: WeaponRifleBarghestNCSP
   result: WeaponRifleBarghest
   completetime: 4
   materials:
@@ -222,7 +222,7 @@
     Plasma: 500
 
 - type: latheRecipe
-  id: WeaponLauncherRocketNCSP #TBD
+  id: WeaponLauncherRocketNCSP
   result: WeaponLauncherRocket
   completetime: 4
   materials:
@@ -230,7 +230,7 @@
     Plastic: 1000
 
 - type: latheRecipe
-  id: CartridgeRocketNCSP #TBD
+  id: CartridgeRocketNCSP
   result: CartridgeRocket
   completetime: 2
   materials:

--- a/_Crescent/Entities/Recipes/Lathes/piratecrafts.yml
+++ b/_Crescent/Entities/Recipes/Lathes/piratecrafts.yml
@@ -9,6 +9,24 @@
     Cloth: 1000
 
 - type: latheRecipe
+  id: ClothingOuterHardsuitCybersunNCSP #TBD
+  result: ClothingOuterHardsuitCybersun
+  completetime: 4
+  materials:
+    Steel: 4250
+    Plastic: 500
+    Cloth: 1000
+
+- type: latheRecipe
+  id: ClothingOuterHardsuitTraumasecNCSP #TBD
+  result: ClothingOuterHardsuitTraumasec
+  completetime: 4
+  materials:
+    Steel: 4250
+    Plastic: 500
+    Cloth: 1000
+
+- type: latheRecipe
   id: ClothingOuterHardsuitSyndicateBGNCSP
   result: ClothingOuterHardsuitSyndicateBG
   completetime: 4
@@ -80,14 +98,6 @@
     Cloth: 500
 
 - type: latheRecipe
-  id: WeaponPistolCobraNCSP
-  result: WeaponPistolCobra
-  completetime: 4
-  materials:
-    Steel: 1750
-    Plastic: 1500
-
-- type: latheRecipe
   id: WeaponSubMachineGunDrozdNCSP
   result: WeaponSubMachineGunDrozd
   completetime: 4
@@ -131,15 +141,6 @@
     Glass: 250
 
 - type: latheRecipe
-  id: NCSPVulcanTurretFlatpackNCSP
-  result: NCSPVulcanTurretFlatpack
-  completetime: 4
-  materials:
-    Steel: 3500
-    Plastic: 550
-    Silver: 500
-
-- type: latheRecipe
   id: NCSPAnklebiterFlatpackNCSP
   result: NCSPAnklebiterFlatpack
   completetime: 4
@@ -158,11 +159,42 @@
     Plasma: 250
 
 - type: latheRecipe
-  id: WeaponRifleKrinkovNCSP
-  result: WeaponRifleKrinkov
+  id: FlakCannonTurretFlatpackCraftNCSP #TBD
+  result: FlakCannonTurretFlatpack
+  completetime: 4
+  materials:
+    Steel: 3000
+    Plastic: 1500
+    Plasma: 1000
+
+- type: latheRecipe
+  id: BaseWeaponTurretGargoyleFlatpackCraftNCSP #TBD
+  result: BaseWeaponTurretGargoyleFlatpack
+  completetime: 4
+  materials:
+    Steel: 4000
+    Plastic: 2000
+    Plasma: 1500
+
+- type: latheRecipe
+  id: EnergyShieldNCSP #TBD
+  result: EnergyShield
+  completetime: 4
+  materials:
+    Steel: 1000
+    Plastic: 500
+    Gold: 500
+    Plasma: 1500
+
+- type: latheRecipe
+  id: EnergySwordNCSP #TBD
+  result: EnergySword
   completetime: 4
   materials:
     Steel: 1500
+    Plastic: 500
+    Silver: 500
+    Plasma: 1500
 
 - type: latheRecipe
   id: WeaponRifleMayflowerNCSP
@@ -173,20 +205,37 @@
     Plastic: 1000
 
 - type: latheRecipe
-  id: WeaponRifleAkNCSP
-  result: WeaponRifleAk
-  completetime: 4
-  materials:
-    Steel: 2250
-    Plastic: 750
-
-- type: latheRecipe
   id: WeaponLightMachineGunL6CNCSP
   result: WeaponLightMachineGunL6
   completetime: 4
   materials:
     Steel: 5250
     Plastic: 1750
+
+- type: latheRecipe
+  id: WeaponRifleBarghestNCSP #TBD
+  result: WeaponRifleBarghest
+  completetime: 4
+  materials:
+    Steel: 5000
+    Plastic: 1500
+    Plasma: 500
+
+- type: latheRecipe
+  id: WeaponLauncherRocketNCSP #TBD
+  result: WeaponLauncherRocket
+  completetime: 4
+  materials:
+    Steel: 3000
+    Plastic: 1000
+
+- type: latheRecipe
+  id: CartridgeRocketNCSP #TBD
+  result: CartridgeRocket
+  completetime: 2
+  materials:
+    Steel: 400
+    Plasma: 400
 
 - type: latheRecipe
   id: MagazineLightRifleBoxNCSP
@@ -213,7 +262,6 @@
   materials:
     Plastic: 1000
     Gold: 500
-    # Diamond: 250 YAMLFIX: Not a real material
     Silver: 750
     Uranium: 1000
 
@@ -223,15 +271,5 @@
   completetime: 4
   materials:
     Steel: 500
-    # Diamond: 750 YAMLFIX: Not a real material
     Plasma: 250
     Silver: 100
-
-
-# - type: latheRecipe
-#   id: GrenadeEMPCraft
-#   result: GrenadeEMP YAMLFIX: Duplicate result
-#   completetime: 4
-#   materials:
-#     Steel: 250
-#     Silver: 100

--- a/_Crescent/Entities/Structures/lathe.yml
+++ b/_Crescent/Entities/Structures/lathe.yml
@@ -398,6 +398,8 @@
       - WeaponPistolHKUSPNT
       - ClothingOuterHardsuitSyndicateBGNCSP
       - ClothingOuterHardsuitRamziNCSP
+      - ClothingOuterHardsuitCybersunNCSP
+      - ClothingOuterHardsuitTraumasecNCSP
       - ClothingHeadHelmetSyndicateBasicInterdyneNCSP
       - ClothingHeadHelmetSyndicateBasicNCSP
       - ClothingUniformJumpsuitSyndicateNCSP
@@ -406,22 +408,25 @@
       - ClothingUniformJumpsuitSyndicateSawsNCSP
       - ClothingUniformJumpsuitSyndicateInterdyneNCSP
       - ClothingNeckScarfSyndicateShemaghNCSP
-      - WeaponPistolCobraNCSP
       - WeaponSubMachineGunAtreidesNCSP
       - WeaponSubMachineGunDrozdNCSP
       - NCSPWarshipThrusterFlatpackNCSP
       - NCSPFighterThrusterFlatpackNCSP
-      - NCSPVulcanTurretFlatpackNCSP
       - NCSPAnklebiterFlatpackNCSP
+      - FlakCannonTurretFlatpackCraftNCSP
+      - BaseWeaponTurretGargoyleFlatpackCraftNCSP
       - PlasmaRepeaterFlatpackCraft
-      - WeaponRifleKrinkovNCSP
+      - EnergyShieldNCSP
+      - EnergySwordNCSP
+      - WeaponRifleBarghestNCSP
+      - WeaponLauncherRocketNCSP
       - WeaponRifleMayflowerNCSP
-      - WeaponRifleAkNCSP
       - WeaponLightMachineGunL6CNCSP
       - MagazineLightRifleBoxNCSP
       - RadioJammerNCSP
       - EmagNCSP
       - EmpGrenadeNCSP
+      - CartridgeRocketNCSP
       # - GrenadeEMPCraft YAMLFIX: Duplicate recipe result
       - ClothingUniformJumpsuitNCWLMedicCraft
       - ClothingUniformJumpsuitNCWLCraft

--- a/_Crescent/Research/pirate.yml
+++ b/_Crescent/Research/pirate.yml
@@ -1,4 +1,65 @@
 - type: technology
+  id: SyndicateClothes
+  name: research-technology-syndieclothes
+  icon:
+    sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndiearmor.rsi
+    state: icon
+  discipline: Pirate
+  tier: 1
+  cost: 1500
+  recipeUnlocks:
+  - ClothingHeadHelmetSyndicateBasicNCSP
+  - ClothingHeadHelmetSyndicateBasicInterdyneNCSP
+  - ClothingOuterArmorSyndicateArmorvestNCSP
+  - ClothingOuterArmorSyndicateArmorvestInterdyneNCSP
+  - ClothingUniformJumpsuitSyndicateNCSP
+  - ClothingUniformJumpsuitSyndicateInterdyneNCSP
+  - ClothingUniformJumpsuitSyndicateSawsNCSP
+  - ClothingNeckScarfSyndicateShemaghNCSP
+
+- type: technology
+  id: SyndicateAviation
+  name: research-technology-syndieaviation
+  icon:
+    sprite: Objects/Devices/flatpack.rsi
+    state: ame-part
+  discipline: Pirate
+  tier: 1
+  cost: 5000
+  recipeUnlocks:
+  # - GyroscopeFlatpackLathe YAMLFIX Fails tests - not printable
+  - NCSPWarshipThrusterFlatpackNCSP
+  - NCSPFighterThrusterFlatpackNCSP
+
+- type: technology
+  id: SyndicateSmallArms
+  name: research-technology-syndiesmallarms
+  icon:
+    sprite: Objects/Weapons/Guns/Pistols/cobra.rsi
+    state: icon
+  discipline: Pirate
+  tier: 1
+  cost: 8000
+  recipeUnlocks:
+  - WeaponPistolCobraNCSP
+  - WeaponSubMachineGunAtreidesNCSP
+  - WeaponSubMachineGunDrozdNCSP
+
+- type: technology
+  id: SyndicateShuttleArmaments
+  name: research-technology-syndieshuttlearmaments
+  icon:
+    sprite: _Crescent/Ammunition/vulcan.rsi
+    state: base
+  discipline: Pirate
+  tier: 2
+  cost: 12500
+  recipeUnlocks:
+  - NCSPVulcanTurretFlatpackNCSP
+  - NCSPAnklebiterFlatpackNCSP
+  - PlasmaRepeaterFlatpackCraft
+
+- type: technology
   id: SyndicateHardsuit
   name: research-technology-syndiehards
   icon:
@@ -34,67 +95,6 @@
   cost: 15000
   recipeUnlocks:
   - WolfLPC
-
-- type: technology
-  id: SyndicateClothes
-  name: research-technology-syndieclothes
-  icon:
-    sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndiearmor.rsi
-    state: icon
-  discipline: Pirate
-  tier: 1
-  cost: 1500
-  recipeUnlocks:
-  - ClothingHeadHelmetSyndicateBasicNCSP
-  - ClothingHeadHelmetSyndicateBasicInterdyneNCSP
-  - ClothingOuterArmorSyndicateArmorvestNCSP
-  - ClothingOuterArmorSyndicateArmorvestInterdyneNCSP
-  - ClothingUniformJumpsuitSyndicateNCSP
-  - ClothingUniformJumpsuitSyndicateInterdyneNCSP
-  - ClothingUniformJumpsuitSyndicateSawsNCSP
-  - ClothingNeckScarfSyndicateShemaghNCSP
-
-- type: technology
-  id: SyndicateSmallArms
-  name: research-technology-syndiesmallarms
-  icon:
-    sprite: Objects/Weapons/Guns/Pistols/cobra.rsi
-    state: icon
-  discipline: Pirate
-  tier: 1
-  cost: 8000
-  recipeUnlocks:
-  - WeaponPistolCobraNCSP
-  - WeaponSubMachineGunAtreidesNCSP
-  - WeaponSubMachineGunDrozdNCSP
-
-- type: technology
-  id: SyndicateAviation
-  name: research-technology-syndieaviation
-  icon:
-    sprite: Objects/Devices/flatpack.rsi
-    state: ame-part
-  discipline: Pirate
-  tier: 1
-  cost: 5000
-  recipeUnlocks:
-  # - GyroscopeFlatpackLathe YAMLFIX Fails tests - not printable
-  - NCSPWarshipThrusterFlatpackNCSP
-  - NCSPFighterThrusterFlatpackNCSP
-
-- type: technology
-  id: SyndicateShuttleArmaments
-  name: research-technology-syndieshuttlearmaments
-  icon:
-    sprite: _Crescent/Ammunition/vulcan.rsi
-    state: base
-  discipline: Pirate
-  tier: 2
-  cost: 12500
-  recipeUnlocks:
-  - NCSPVulcanTurretFlatpackNCSP
-  - NCSPAnklebiterFlatpackNCSP
-  - PlasmaRepeaterFlatpackCraft
 
 - type: technology
   id: SyndicateLongArms

--- a/_Crescent/Research/pirate.yml
+++ b/_Crescent/Research/pirate.yml
@@ -6,7 +6,7 @@
     state: icon
   discipline: Pirate
   tier: 1
-  cost: 1000
+  cost: 2500
   recipeUnlocks:
   - ClothingHeadHelmetSyndicateBasicNCSP
   - ClothingHeadHelmetSyndicateBasicInterdyneNCSP

--- a/_Crescent/Research/pirate.yml
+++ b/_Crescent/Research/pirate.yml
@@ -57,8 +57,8 @@
   recipeUnlocks:
   - ClothingOuterHardsuitSyndicateBGNCSP
   - ClothingOuterHardsuitRamziNCSP
-# - ClothingOuterHardsuitCybersunNCSP - NEEDS RECIPE
-# - ClothingOuterHardsuitTraumasecNCSP - NEEDS RECIPE
+  - ClothingOuterHardsuitCybersunNCSP
+  - ClothingOuterHardsuitTraumasecNCSP
 
 - type: technology
   id: Sinn
@@ -85,8 +85,8 @@
   - NCSPAnklebiterFlatpackNCSP
   - PlasmaRepeaterFlatpackCraft
   - SHIArtilleryFlatpackCraft
- # - FlakCannonTurretFlatpackCraftNCSP - NEEDS RECIPE
- # - BaseWeaponTurretGargoyleFlatpackCraftNCSP - NEEDS RECIPE
+  - FlakCannonTurretFlatpackCraftNCSP
+  - BaseWeaponTurretGargoyleFlatpackCraftNCSP
 
 - type: technology
   id: Wolf
@@ -113,8 +113,8 @@
   - EmagNCSP
   - RadioJammerNCSP
   - EmpGrenadeNCSP
-# - EnergyShieldNCSP - NEEDS RECIPE
-# - EnergySwordNCSP - NEEDS RECIPE
+  - EnergyShieldNCSP
+  - EnergySwordNCSP
 
 - type: technology
   id: SyndicateLongArms
@@ -128,6 +128,6 @@
   recipeUnlocks:
   - WeaponLightMachineGunL6CNCSP
   - MagazineLightRifleBoxNCSP
-# - WeaponRifleBarghestNCSP - NEEDS RECIPE
-# - WeaponLauncherRocketNCSP - NEEDS RECIPE
-# - CartridgeRocket - NEEDS RECIPE
+  - WeaponRifleBarghestNCSP
+  - WeaponLauncherRocketNCSP
+  - CartridgeRocket

--- a/_Crescent/Research/pirate.yml
+++ b/_Crescent/Research/pirate.yml
@@ -6,7 +6,7 @@
     state: icon
   discipline: Pirate
   tier: 1
-  cost: 1500
+  cost: 1000
   recipeUnlocks:
   - ClothingHeadHelmetSyndicateBasicNCSP
   - ClothingHeadHelmetSyndicateBasicInterdyneNCSP
@@ -25,7 +25,7 @@
     state: ame-part
   discipline: Pirate
   tier: 1
-  cost: 5000
+  cost: 2500
   recipeUnlocks:
   # - GyroscopeFlatpackLathe YAMLFIX Fails tests - not printable
   - NCSPWarshipThrusterFlatpackNCSP
@@ -39,11 +39,38 @@
     state: icon
   discipline: Pirate
   tier: 1
-  cost: 8000
+  cost: 5000
   recipeUnlocks:
-  - WeaponPistolCobraNCSP
   - WeaponSubMachineGunAtreidesNCSP
   - WeaponSubMachineGunDrozdNCSP
+# - WeaponShotgunEnforcer - NEEDS RECIPE
+
+- type: technology
+  id: SyndicateHardsuit
+  name: research-technology-syndiehards
+  icon:
+    sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndicatesbg.rsi
+    state: icon
+  discipline: Pirate
+  tier: 2
+  cost: 7500
+  recipeUnlocks:
+  - ClothingOuterHardsuitSyndicateBGNCSP
+  - ClothingOuterHardsuitRamziNCSP
+# - ClothingOuterHardsuitCybersun - NEEDS RECIPE
+# - ClothingOuterHardsuitTraumasec - NEEDS RECIPE
+
+- type: technology
+  id: Sinn
+  name: research-technology-sinn
+  icon:
+    sprite: _Crescent/Objects/Misc/lpcchip.rsi
+    state: icon
+  discipline: Pirate
+  tier: 2
+  cost: 10000
+  recipeUnlocks:
+  - SinnLPC
 
 - type: technology
   id: SyndicateShuttleArmaments
@@ -55,34 +82,11 @@
   tier: 2
   cost: 12500
   recipeUnlocks:
-  - NCSPVulcanTurretFlatpackNCSP
-  - NCSPAnklebiterFlatpackNCSP
+  - NCSPVulcanTurretFlatpackNCSP  #fires faster, bullets are slower, needs to be manually reloaded
+  - NCSPAnklebiterFlatpackNCSP    #fires considerably slower, bullets are faster, reloads automatically
   - PlasmaRepeaterFlatpackCraft
-
-- type: technology
-  id: SyndicateHardsuit
-  name: research-technology-syndiehards
-  icon:
-    sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndicatesbg.rsi
-    state: icon
-  discipline: Pirate
-  tier: 2
-  cost: 12500
-  recipeUnlocks:
-  - ClothingOuterHardsuitSyndicateBGNCSP
-  - ClothingOuterHardsuitRamziNCSP
-
-- type: technology
-  id: Sinn
-  name: research-technology-sinn
-  icon:
-    sprite: _Crescent/Objects/Misc/lpcchip.rsi
-    state: icon
-  discipline: Pirate
-  tier: 2
-  cost: 12500
-  recipeUnlocks:
-  - SinnLPC
+  - HardlineBeamPulserFlatpack
+  - SHIArtilleryFlatpackCraft
 
 - type: technology
   id: Wolf
@@ -91,10 +95,26 @@
     sprite: _Crescent/Objects/Misc/lpcchip.rsi
     state: icon
   discipline: Pirate
-  tier: 3
-  cost: 15000
+  tier: 2
+  cost: 12500
   recipeUnlocks:
   - WolfLPC
+
+- type: technology
+  id: SyndicateEwar
+  name: research-technology-syndieewar
+  icon:
+    sprite: Objects/Tools/emag.rsi
+    state: icon
+  discipline: Pirate
+  tier: 3
+  cost: 17500
+  recipeUnlocks:
+  - EmagNCSP
+  - RadioJammerNCSP
+  - EmpGrenadeNCSP
+# - EnergyShield - NEEDS RECIPE
+# - EnergySword - NEEDS RECIPE
 
 - type: technology
   id: SyndicateLongArms
@@ -106,23 +126,9 @@
   tier: 3
   cost: 20000
   recipeUnlocks:
-  - WeaponRifleKrinkovNCSP
   - WeaponRifleMayflowerNCSP
-  - WeaponRifleAkNCSP
   - WeaponLightMachineGunL6CNCSP
   - MagazineLightRifleBoxNCSP
-
-- type: technology
-  id: SyndicateEwar
-  name: research-technology-syndieewar
-  icon:
-    sprite: Objects/Tools/emag.rsi
-    state: icon
-  discipline: Pirate
-  tier: 3
-  cost: 30000
-  recipeUnlocks:
-  - EmagNCSP
-  - RadioJammerNCSP
-  - EmpGrenadeNCSP
-  # - GrenadeEMPCraft YAMLFIX: Duplicate recipe result
+# - WeaponRifleBarghest - NEEDS RECIPE
+# - WeaponLauncherRocket - NEEDS RECIPE
+# - CartridgeRocket - NEEDS RECIPE

--- a/_Crescent/Research/pirate.yml
+++ b/_Crescent/Research/pirate.yml
@@ -43,7 +43,7 @@
   recipeUnlocks:
   - WeaponSubMachineGunAtreidesNCSP
   - WeaponSubMachineGunDrozdNCSP
-# - WeaponShotgunEnforcer - NEEDS RECIPE
+  - WeaponRifleMayflowerNCSP
 
 - type: technology
   id: SyndicateHardsuit
@@ -52,13 +52,13 @@
     sprite: _Crescent/Clothing/Syndicate/OuterClothing/syndicatesbg.rsi
     state: icon
   discipline: Pirate
-  tier: 2
-  cost: 7500
+  tier: 1
+  cost: 5000
   recipeUnlocks:
   - ClothingOuterHardsuitSyndicateBGNCSP
   - ClothingOuterHardsuitRamziNCSP
-# - ClothingOuterHardsuitCybersun - NEEDS RECIPE
-# - ClothingOuterHardsuitTraumasec - NEEDS RECIPE
+# - ClothingOuterHardsuitCybersunNCSP - NEEDS RECIPE
+# - ClothingOuterHardsuitTraumasecNCSP - NEEDS RECIPE
 
 - type: technology
   id: Sinn
@@ -82,11 +82,11 @@
   tier: 2
   cost: 12500
   recipeUnlocks:
-  - NCSPVulcanTurretFlatpackNCSP  #fires faster, bullets are slower, needs to be manually reloaded
-  - NCSPAnklebiterFlatpackNCSP    #fires considerably slower, bullets are faster, reloads automatically
+  - NCSPAnklebiterFlatpackNCSP
   - PlasmaRepeaterFlatpackCraft
-  - HardlineBeamPulserFlatpack
   - SHIArtilleryFlatpackCraft
+ # - FlakCannonTurretFlatpackCraftNCSP - NEEDS RECIPE
+ # - BaseWeaponTurretGargoyleFlatpackCraftNCSP - NEEDS RECIPE
 
 - type: technology
   id: Wolf
@@ -108,13 +108,13 @@
     state: icon
   discipline: Pirate
   tier: 3
-  cost: 17500
+  cost: 15000
   recipeUnlocks:
   - EmagNCSP
   - RadioJammerNCSP
   - EmpGrenadeNCSP
-# - EnergyShield - NEEDS RECIPE
-# - EnergySword - NEEDS RECIPE
+# - EnergyShieldNCSP - NEEDS RECIPE
+# - EnergySwordNCSP - NEEDS RECIPE
 
 - type: technology
   id: SyndicateLongArms
@@ -126,9 +126,8 @@
   tier: 3
   cost: 20000
   recipeUnlocks:
-  - WeaponRifleMayflowerNCSP
   - WeaponLightMachineGunL6CNCSP
   - MagazineLightRifleBoxNCSP
-# - WeaponRifleBarghest - NEEDS RECIPE
-# - WeaponLauncherRocket - NEEDS RECIPE
+# - WeaponRifleBarghestNCSP - NEEDS RECIPE
+# - WeaponLauncherRocketNCSP - NEEDS RECIPE
 # - CartridgeRocket - NEEDS RECIPE


### PR DESCRIPTION
Cleans up the TFSC research tree and makes it viable, it also re-sorts it by price so the diff is completely ruined.

THINGS ADDED:
Prince flak artillery flatpack
Gargoyle missile launcher flatpack

THINGS CHANGED:
added recipes for the 2 flatpacks
added recipes for CD and IPM hardsuits
added recipes for energy shield, energy sword, barghest, RPG-7
pirate tech prices dropped across the board, the tree now costs 95k in total at a low tech card amount
cleaned up some yaml gunk
e-sword damage increased by 8 to be a closer competitor to the hardlight sword

THINGS REMOVED:
ak, krinkov, cobra, vulcan turret recipes

NEW TREE:
T1 2.5K - CLOTHES
T1 2.5K - THRUSTERS
T1 5K - ATREIDES, DROZD, MAYFLOWER
T1 5K - HARDSUITS
T2 10K - SINN
T2 12.5K - RECHARGING PDT, PLASMA REPEATER, 120MM CANNON, FLAK CANNON, GARGOYLE
T2 12.5K - WOLF
T3 15K - EMAG, RADIO JAMMER, EMP GRENADE, ESWORD, ESHIELD
T3 20K - L6, L6 MAGS, ~~BARGHEST~~, RPG, RPG MISSILES

95K TOTAL

needs tests in-game because this is 100% natural webedit

post-merge the barghest was removed, this tree still needs the SAW jugsuit and plasma cutter, ultralights and maybe more R&D only ships (like the sinn), the t3 heavy guns tech needs an AMR and the wolf tech card needs bundling with other TFSC purchasable cruisers (e.g. rokh, hulk, etc.)