### PR TITLE
Holoparasite buff

### DIFF
--- a/Entities/Mobs/Player/guardian.yml
+++ b/Entities/Mobs/Player/guardian.yml
@@ -20,7 +20,7 @@
     - type: InputMover
     - type: MovementSpeedModifier
       baseWalkSpeed: 4
-      baseSprintSpeed: 5.5
+      baseSprintSpeed: 6
     - type: DamageOnHighSpeedImpact
       damage:
         types:
@@ -86,14 +86,14 @@
       hidden: false
       altDisarm: false
       animation: WeaponArcFist
-      attackRate: 1.8
+      attackRate: 2
       autoAttack: true
       soundHit:
         collection: Punch
       damage:
         types:
-          Blunt: 20
-          Structural: 60
+          Blunt: 30
+          Structural: 70
     - type: MeleeSpeech
     - type: UserInterface
       interfaces:
@@ -138,7 +138,7 @@
           color: "#40a7d7"
           shader: unshaded
     - type: Guardian
-      distanceAllowed: 15 
+      distanceAllowed: 30 
     # - type: HTN # Frontier
       # rootTask:
         # task: SimpleHumanoidHostileCompound


### PR DESCRIPTION
They can be hit by bullets now, so its only fair that they become more lethal as otherwise they are a borderline useless (and boring) ghostrole.

Buffs several things overall. 

Do note that these changes only make a capable holoparasite player even deadlier. If they don't know what they are doing they're useless.