### PR TITLE
Gives ATH a bit more heft on spawn.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
   <component name="ChangeListManager">
-    <list default="true" id="0ce08445-971c-4f03-8f68-0ebe6da24582" name="Changes" comment="" />
+    <list default="true" id="0ce08445-971c-4f03-8f68-0ebe6da24582" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/_Crescent/Catalog/Fills/StarterGear/starterfills.yml" beforeDir="false" afterPath="$PROJECT_DIR$/_Crescent/Catalog/Fills/StarterGear/starterfills.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/_Crescent/Loadouts/role_loadouts.yml" beforeDir="false" afterPath="$PROJECT_DIR$/_Crescent/Loadouts/role_loadouts.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/kanoneer.yml" beforeDir="false" afterPath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/kanoneer.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/kommandant.yml" beforeDir="false" afterPath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/kommandant.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/leutnant.yml" beforeDir="false" afterPath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/leutnant.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/sanitat.yml" beforeDir="false" afterPath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/sanitat.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/soldat.yml" beforeDir="false" afterPath="$PROJECT_DIR$/_Crescent/Roles/Jobs/ATH/soldat.yml" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -23,6 +35,10 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
     "git-widget-placeholder": "main",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }
@@ -37,6 +53,7 @@
       <updated>1740607918729</updated>
       <workItem from="1740607918732" duration="27000" />
       <workItem from="1740774626547" duration="20000" />
+      <workItem from="1743348619904" duration="8627000" />
     </task>
     <servers />
   </component>

--- a/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
+++ b/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
@@ -379,3 +379,40 @@
         - id: SuperCapacitorStockPart
         - id: SuperCapacitorStockPart
         - id: SuperCapacitorStockPart
+
+#ATH
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpack
+  id: ClothingBackpackAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: MagazinePistol
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackSatchel
+  id: ClothingBackpackSatchelAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: MagazinePistol 
+          
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackDuffel
+  id: ClothingBackpackDuffelAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: MagazinePistol

--- a/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
@@ -1,0 +1,7 @@
+- type: loadoutGroup
+  id: ATHBackpacks
+  name: loadout-group-contractor-backpack
+  loadouts:
+    - ClothingBackpackAuthorityFilled
+    - ClothingBackpackSatchelAuthorityFilled
+    - ClothingBackpackDuffelAuthorityFilled

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -440,19 +440,20 @@
   id: JobSoldatATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHBackpacks
+  - ContractorFun # For Oni Usage ONLY.
 
 - type: roleLoadout
   id: JobKanoneerATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHBackpacks
 
 - type: roleLoadout
   id: JobSanitatATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHBackpacks
 
 #misc
 

--- a/_Crescent/Roles/Jobs/ATH/kanoneer.yml
+++ b/_Crescent/Roles/Jobs/ATH/kanoneer.yml
@@ -65,9 +65,10 @@
   id: KanoneerGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityKanoneer
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityKanoneer
     belt: ClothingBeltAuthorityWebbing
     gloves: ClothingHandsGlovesFingerless
     id: KanoneerPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponPistolViper

--- a/_Crescent/Roles/Jobs/ATH/kommandant.yml
+++ b/_Crescent/Roles/Jobs/ATH/kommandant.yml
@@ -69,9 +69,10 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityKommandant
     back: ClothingBackpackSatchelLeatherFilledDSM
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityKommandant
     outerClothing: ClothingOuterCoatAuthorityKommandant
     belt: ClothingBeltSheathFilled
     id: KommandantPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponRevolverInspector

--- a/_Crescent/Roles/Jobs/ATH/leutnant.yml
+++ b/_Crescent/Roles/Jobs/ATH/leutnant.yml
@@ -68,8 +68,9 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityLeutnant
     back: ClothingBackpackSatchelLeatherFilledDSM
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityLeutnant
     outerClothing: ClothingOuterCoatAuthorityLeutnant
     id: LeutnantPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponRevolverInspector

--- a/_Crescent/Roles/Jobs/ATH/sanitat.yml
+++ b/_Crescent/Roles/Jobs/ATH/sanitat.yml
@@ -66,9 +66,10 @@
   id: SanitatGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthoritySanitat
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthoritySanitat
     belt: ClothingBeltAuthorityDroppouches
     gloves: ClothingHandsGlovesFingerless
     id: SanitatPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponPistolViper

--- a/_Crescent/Roles/Jobs/ATH/soldat.yml
+++ b/_Crescent/Roles/Jobs/ATH/soldat.yml
@@ -65,9 +65,10 @@
   id: SoldatGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthoritySoldat
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthoritySoldat
     belt: ClothingBeltAuthorityPouches
     gloves: ClothingHandsGlovesFingerless
     id: SoldatPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponPistolViper


### PR DESCRIPTION
Changes:
- All ATH jobs receive filled Combat Boots.

- Soldat, Sanitar and Kanoner receive PTA 9mm Vipers to their pockets. 

- All ATH jobs except Kommandant and Leutnant, receive a survival box, flash, ziptie and pistol magazine inside their chosen backpack through the addition of ath_loadouts.yml. 

This should work straight out of the box but someone please test first. 
Kommandant and Leutnant have DSM derived filled Leather Satchels, not changing that in this PR.

oslo2673