### PR TITLE
Authoritat loadout fix up

### DIFF
--- a/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
+++ b/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
@@ -379,3 +379,52 @@
         - id: SuperCapacitorStockPart
         - id: SuperCapacitorStockPart
         - id: SuperCapacitorStockPart
+
+#ATH
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpack
+  id: ClothingBackpackAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackSatchel
+  id: ClothingBackpackSatchelAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackDuffel
+  id: ClothingBackpackDuffelAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackSatchelLeather
+  id: ClothingBackpackSatchelLeatherAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel

--- a/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
@@ -1,0 +1,15 @@
+- type: loadoutGroup
+  id: ATHBackpacks
+  name: loadout-group-contractor-backpack
+  loadouts:
+    - ClothingBackpackAuthorityFilled
+    - ClothingBackpackSatchelAuthorityFilled
+    - ClothingBackpackDuffelAuthorityFilled
+
+- type: loadoutGroup
+  id: ATHWebbings
+  name: loadout-group-contractor-belt
+  loadouts:
+    - ClothingBeltAuthorityWebbing
+    - ClothingBeltAuthorityPouches
+    - ClothingBeltAuthorityDroppouches

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -448,8 +448,8 @@
   id: JobKanoneerATH
   groups:
   - ContractorTrinkets
-  - ATHWebbings
-  #- ATHBackpacks
+  - ATHBackpacks
+  #- ATHWebbings
 
 - type: roleLoadout
   id: JobSanitatATH

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -435,24 +435,28 @@
   id: JobLeutnantATH
   groups:
   - ContractorTrinkets
-
+  - ATHWebbings
+  
 - type: roleLoadout
   id: JobSoldatATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHBackpacks
+  #- ATHWebbings
 
 - type: roleLoadout
   id: JobKanoneerATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHWebbings
+  #- ATHBackpacks
 
 - type: roleLoadout
   id: JobSanitatATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHBackpacks
+  #- ATHWebbings
 
 #misc
 

--- a/_Crescent/Roles/Jobs/ATH/kanoneer.yml
+++ b/_Crescent/Roles/Jobs/ATH/kanoneer.yml
@@ -65,7 +65,7 @@
   id: KanoneerGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityKanoneer
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityKanoneer
     belt: ClothingBeltAuthorityWebbing
     gloves: ClothingHandsGlovesFingerless

--- a/_Crescent/Roles/Jobs/ATH/kommandant.yml
+++ b/_Crescent/Roles/Jobs/ATH/kommandant.yml
@@ -68,8 +68,8 @@
   id: KommandantGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityKommandant
-    back: ClothingBackpackSatchelLeatherFilledDSM
-    shoes: ClothingShoesBootsJack
+    back: ClothingBackpackSatchelLeatherAuthorityFilled
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityKommandant
     outerClothing: ClothingOuterCoatAuthorityKommandant
     belt: ClothingBeltSheathFilled

--- a/_Crescent/Roles/Jobs/ATH/leutnant.yml
+++ b/_Crescent/Roles/Jobs/ATH/leutnant.yml
@@ -67,8 +67,8 @@
   id: LeutnantGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityLeutnant
-    back: ClothingBackpackSatchelLeatherFilledDSM
-    shoes: ClothingShoesBootsJack
+    back: ClothingBackpackSatchelLeatherAuthorityFilled
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityLeutnant
     outerClothing: ClothingOuterCoatAuthorityLeutnant
     id: LeutnantPDA

--- a/_Crescent/Roles/Jobs/ATH/sanitat.yml
+++ b/_Crescent/Roles/Jobs/ATH/sanitat.yml
@@ -66,7 +66,7 @@
   id: SanitatGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthoritySanitat
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthoritySanitat
     belt: ClothingBeltAuthorityDroppouches
     gloves: ClothingHandsGlovesFingerless

--- a/_Crescent/Roles/Jobs/ATH/soldat.yml
+++ b/_Crescent/Roles/Jobs/ATH/soldat.yml
@@ -65,7 +65,7 @@
   id: SoldatGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthoritySoldat
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthoritySoldat
     belt: ClothingBeltAuthorityPouches
     gloves: ClothingHandsGlovesFingerless


### PR DESCRIPTION
Changes:

- All ATH jobs receive filled Combat Boots.

- All ATH jobs receive a survival box, flash, zipties and a shrapnel grenade. Not sure which one Reggie wants to see more of.

- Soldat, Sanitat and Kanoneer can now pick between a filled Satchel, Backpack or Duffel bag.

- Kommandant/Konteradmiral and Leutnant have Authoritat derived filled Leather Satchels now.

- Leutnants can select a webbing from loadout.