### PR TITLE
Sol Rises: Loadouts and Starter Gear

### DIFF
--- a/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
+++ b/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
@@ -379,3 +379,52 @@
         - id: SuperCapacitorStockPart
         - id: SuperCapacitorStockPart
         - id: SuperCapacitorStockPart
+
+#ATH
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpack
+  id: ClothingBackpackAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackSatchel
+  id: ClothingBackpackSatchelAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackDuffel
+  id: ClothingBackpackDuffelAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: ClothingBackpackSatchelLeather
+  id: ClothingBackpackSatchelLeatherAuthorityFilled
+  components:
+    - type: StorageFill
+      contents:
+        - id: BoxSurvival
+        - id: Flash
+        - id: Zipties
+        - id: GrenadeShrapnel

--- a/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
+++ b/_Crescent/Catalog/Fills/StarterGear/starterfills.yml
@@ -391,7 +391,6 @@
         - id: BoxSurvival
         - id: Flash
         - id: Zipties
-        - id: GrenadeShrapnel
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -403,7 +402,6 @@
         - id: BoxSurvival
         - id: Flash
         - id: Zipties
-        - id: GrenadeShrapnel
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -415,7 +413,6 @@
         - id: BoxSurvival
         - id: Flash
         - id: Zipties
-        - id: GrenadeShrapnel
 
 - type: entity
   categories: [ HideSpawnMenu ]
@@ -427,4 +424,3 @@
         - id: BoxSurvival
         - id: Flash
         - id: Zipties
-        - id: GrenadeShrapnel

--- a/_Crescent/Loadouts/Jobs/ATH/bags.yml
+++ b/_Crescent/Loadouts/Jobs/ATH/bags.yml
@@ -1,0 +1,26 @@
+- type: loadout
+  id: ATHClothingBackpackAuthorityFilled
+  equipment: ATHClothingBackpackAuthorityFilled
+  price: 0
+
+- type: startingGear
+  id: ATHClothingBackpackAuthorityFilled
+  equipment:
+    back: ClothingBackpackAuthorityFilled
+    
+- type: loadout
+  id: ATHClothingBackpackSatchelAuthorityFilled
+  price: 0
+    
+- type: startingGear
+  id: ATHClothingBackpackSatchelAuthorityFilled
+  equipment:
+    back: ClothingBackpackSatchelAuthorityFilled
+    
+- type: loadout
+  id: ATHClothingBackpackDuffelAuthorityFilled
+  price: 0
+  
+- type: startingGear
+  equipment:
+    back: ClothingBackpackDuffelAuthorityFilled

--- a/_Crescent/Loadouts/Jobs/ATH/belt.yml
+++ b/_Crescent/Loadouts/Jobs/ATH/belt.yml
@@ -1,0 +1,29 @@
+- type: loadout
+  id: ATHClothingBeltAuthorityWebbing
+  equipment: ATHClothingBeltAuthorityWebbing
+  price: 0
+
+- type: startingGear
+  id: ATHClothingBeltAuthorityWebbing
+  equipment:
+    belt: ClothingBeltAuthorityWebbing
+    
+- type: loadout
+  id: ATHClothingBeltAuthorityPouches
+  equipment: ATHClothingBeltAuthorityPouches
+  price: 0
+
+- type: startingGear
+  id: ATHClothingBeltAuthorityPouches
+  equipment:
+    belt: ClothingBeltAuthorityPouches
+    
+- type: loadout
+  id: ATHClothingBeltAuthorityDroppouches
+  equipment: ATHClothingBeltAuthorityDroppouches
+  price: 0
+
+- type: startingGear
+  id: ATHClothingBeltAuthorityDroppouches
+  equipment:
+    belt: ClothingBeltAuthorityDroppouches

--- a/_Crescent/Loadouts/Jobs/ATH/eyes.yml
+++ b/_Crescent/Loadouts/Jobs/ATH/eyes.yml
@@ -1,0 +1,29 @@
+- type: loadout
+  id: ATHClothingEyesGlassesSunglasses
+  equipment: ATHClothingEyesGlassesSunglasses
+  price: 0
+
+- type: startingGear
+  id: ATHClothingEyesGlassesSunglasses
+  equipment:
+    eyes: ClothingEyesGlassesSunglasses
+    
+- type: loadout
+  id: ATHClothingEyesEyepatch
+  equipment: ATHClothingEyesEyepatch
+  price: 0
+
+- type: startingGear
+  id: ATHClothingEyesEyepatch
+  equipment:
+    eyes: ClothingEyesEyepatch
+    
+- type: loadout
+  id: ATHClothingEyesGlasses
+  equipment: ATHClothingEyesGlasses
+  price: 0
+
+- type: startingGear
+  id: ATHClothingEyesGlasses
+  equipment:
+    eyes: ClothingEyesGlasses

--- a/_Crescent/Loadouts/Jobs/ATH/fun.yml
+++ b/_Crescent/Loadouts/Jobs/ATH/fun.yml
@@ -1,0 +1,29 @@
+- type: loadout
+  id: ATHHarmonicaInstrument
+  equipment: ATHHarmonicaInstrument
+  price: 500
+
+- type: startingGear
+  id: ATHHarmonicaInstrument
+  inhand:
+    - HarmonicaInstrument
+      
+- type: loadout
+  id: ATHSaxophoneInstrument
+  equipment: ATHSaxophoneInstrument
+  price: 500
+
+- type: startingGear
+  id: ATHSaxophoneInstrument
+  inhand:
+    - SaxophoneInstrument
+      
+- type: loadout
+  id: ATHAcousticGuitarInstrument
+  equipment: ATHAcousticGuitarInstrument
+  price: 500
+
+- type: startingGear
+  id: ATHAcousticGuitarInstrument
+  inhand:
+    - AcousticGuitarInstrument

--- a/_Crescent/Loadouts/Jobs/ATH/gloves.yml
+++ b/_Crescent/Loadouts/Jobs/ATH/gloves.yml
@@ -1,0 +1,19 @@
+- type: loadout
+  id: ATHClothingHandsGlovesFingerless
+  equipment: ATHClothingHandsGlovesFingerless
+  price: 0
+
+- type: startingGear
+  id: ATHClothingHandsGlovesFingerless
+  equipment:
+    gloves: ClothingHandsGlovesFingerless
+    
+- type: loadout
+  id: ATHClothingHandsGlovesCombat
+  equipment: ATHClothingHandsGlovesCombat
+  price: 0
+
+- type: startingGear
+  id: ATHClothingHandsGlovesCombat
+  equipment:
+    gloves: ClothingHandsGlovesCombat

--- a/_Crescent/Loadouts/Jobs/ATH/shoes.yml
+++ b/_Crescent/Loadouts/Jobs/ATH/shoes.yml
@@ -1,0 +1,19 @@
+- type: loadout
+  id: ATHClothingShoesBootsCombatFilled
+  equipment: ATHClothingShoesBootsCombatFilled
+  price: 0
+
+- type: startingGear
+  id: ATHClothingShoesBootsCombatFilled
+  equipment:
+    shoes: ClothingShoesBootsCombatFilled
+    
+- type: loadout
+  id: ATHClothingShoesBootsJack
+  equipment: ATHClothingShoesBootsJack
+  price: 0
+
+- type: startingGear
+  id: ATHClothingShoesBootsJack
+  equipment:
+    shoes: ClothingShoesBootsJack

--- a/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
@@ -1,0 +1,15 @@
+- type: loadoutGroup
+  id: ATHBackpacks
+  name: loadout-group-contractor-backpack
+  loadouts:
+    - ClothingBackpackAuthorityFilled
+    - ClothingBackpackSatchelAuthorityFilled
+    - ClothingBackpackDuffelAuthorityFilled
+
+- type: loadoutGroup
+  id: ATHWebbings
+  name: loadout-group-contractor-belt
+  loadouts:
+    - ClothingBeltAuthorityWebbing
+    - ClothingBeltAuthorityPouches
+    - ClothingBeltAuthorityDroppouches

--- a/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
+++ b/_Crescent/Loadouts/LoadoutGroups/ATH/ath_loadouts.yml
@@ -2,14 +2,45 @@
   id: ATHBackpacks
   name: loadout-group-contractor-backpack
   loadouts:
-    - ClothingBackpackAuthorityFilled
-    - ClothingBackpackSatchelAuthorityFilled
-    - ClothingBackpackDuffelAuthorityFilled
+    - ATHClothingBackpackAuthorityFilled
+    - ATHClothingBackpackSatchelAuthorityFilled
+    - ATHClothingBackpackDuffelAuthorityFilled
 
 - type: loadoutGroup
   id: ATHWebbings
   name: loadout-group-contractor-belt
   loadouts:
-    - ClothingBeltAuthorityWebbing
-    - ClothingBeltAuthorityPouches
-    - ClothingBeltAuthorityDroppouches
+    - ATHClothingBeltAuthorityWebbing
+    - ATHClothingBeltAuthorityPouches
+    - ATHClothingBeltAuthorityDroppouches
+
+
+- type: loadoutGroup
+  id: ATHBoots
+  name: loadout-group-contractor-shoes
+  loadouts:
+    - ATHClothingShoesBootsCombatFilled
+    - ATHClothingShoesBootsJack
+      
+- type: loadoutGroup
+  id: ATHGloves
+  name: loadout-group-contractor-gloves
+  loadouts:
+    - ATHClothingHandsGlovesFingerless
+    - ATHClothingHandsGlovesCombat
+      
+- type: loadoutGroup
+  id: ATHEyes
+  name: Loadout-group-contractor-glasses
+  loadouts:
+    - ATHClothingEyesGlassesSunglasses
+    - ATHClothingEyesEyepatch
+    - ATHClothingEyesGlasses
+      
+- type: loadoutGroup
+  id: ATHFun
+  name: Loadout-group-contractor-fun
+  loadouts:
+    - ATHHarmonicaInstrument
+    - ATHSaxophoneInstrument
+    - ATHAcousticGuitarInstrument

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -448,8 +448,8 @@
   id: JobKanoneerATH
   groups:
   - ContractorTrinkets
-  - ATHWebbings
-  #- ATHBackpacks
+  - ATHBackpacks
+  #- ATHWebbings
 
 - type: roleLoadout
   id: JobSanitatATH

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -430,33 +430,54 @@
   id: JobKommandantATH
   groups:
   - ContractorTrinkets
+  - ATHWebbings
+  - ATHBoots
+  - ATHGloves
+  - ATHEyes
+  - ATHFun
 
 - type: roleLoadout
   id: JobLeutnantATH
   groups:
   - ContractorTrinkets
   - ATHWebbings
+  - ATHBoots
+  - ATHGloves
+  - ATHEyes
+  - ATHFun
   
 - type: roleLoadout
   id: JobSoldatATH
   groups:
   - ContractorTrinkets
   - ATHBackpacks
-  #- ATHWebbings
+  - ATHWebbings
+  - ATHBoots
+  - ATHGloves
+  - ATHEyes
+  - ATHFun
 
 - type: roleLoadout
   id: JobKanoneerATH
   groups:
   - ContractorTrinkets
   - ATHBackpacks
-  #- ATHWebbings
+  - ATHWebbings
+  - ATHBoots
+  - ATHGloves
+  - ATHEyes
+  - ATHFun
 
 - type: roleLoadout
   id: JobSanitatATH
   groups:
   - ContractorTrinkets
   - ATHBackpacks
-  #- ATHWebbings
+  - ATHWebbings
+  - ATHBoots
+  - ATHGloves
+  - ATHEyes
+  - ATHFun
 
 #misc
 

--- a/_Crescent/Loadouts/role_loadouts.yml
+++ b/_Crescent/Loadouts/role_loadouts.yml
@@ -435,24 +435,28 @@
   id: JobLeutnantATH
   groups:
   - ContractorTrinkets
-
+  - ATHWebbings
+  
 - type: roleLoadout
   id: JobSoldatATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHBackpacks
+  #- ATHWebbings
 
 - type: roleLoadout
   id: JobKanoneerATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHWebbings
+  #- ATHBackpacks
 
 - type: roleLoadout
   id: JobSanitatATH
   groups:
   - ContractorTrinkets
-  - ContractorBackpack
+  - ATHBackpacks
+  #- ATHWebbings
 
 #misc
 

--- a/_Crescent/Roles/Jobs/ATH/kanoneer.yml
+++ b/_Crescent/Roles/Jobs/ATH/kanoneer.yml
@@ -65,7 +65,7 @@
   id: KanoneerGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityKanoneer
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityKanoneer
     belt: ClothingBeltAuthorityWebbing
     gloves: ClothingHandsGlovesFingerless

--- a/_Crescent/Roles/Jobs/ATH/kanoneer.yml
+++ b/_Crescent/Roles/Jobs/ATH/kanoneer.yml
@@ -71,3 +71,5 @@
     gloves: ClothingHandsGlovesFingerless
     id: KanoneerPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponPistolSmartpistol
+    pocket2: MagazinePistolSmartgun

--- a/_Crescent/Roles/Jobs/ATH/kanoneer.yml
+++ b/_Crescent/Roles/Jobs/ATH/kanoneer.yml
@@ -71,5 +71,5 @@
     gloves: ClothingHandsGlovesFingerless
     id: KanoneerPDA
     ears: ClothingHeadsetAuthority
-    pocket1: WeaponPistolSmartpistol
-    pocket2: MagazinePistolSmartgun
+    pocket1: WeaponPistolMk58
+    pocket2: MagazinePistol

--- a/_Crescent/Roles/Jobs/ATH/kommandant.yml
+++ b/_Crescent/Roles/Jobs/ATH/kommandant.yml
@@ -75,5 +75,5 @@
     belt: ClothingBeltSheathFilled
     id: KommandantPDA
     ears: ClothingHeadsetAuthority
-    pocket1: WeaponRevolverMateba
-    pocket2: SpeedLoaderMagnum
+    pocket1: WeaponPistolN1984
+    pocket2: MagazineMagnum

--- a/_Crescent/Roles/Jobs/ATH/kommandant.yml
+++ b/_Crescent/Roles/Jobs/ATH/kommandant.yml
@@ -68,8 +68,8 @@
   id: KommandantGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityKommandant
-    back: ClothingBackpackSatchelLeatherFilledDSM
-    shoes: ClothingShoesBootsJack
+    back: ClothingBackpackSatchelLeatherAuthorityFilled
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityKommandant
     outerClothing: ClothingOuterCoatAuthorityKommandant
     belt: ClothingBeltSheathFilled

--- a/_Crescent/Roles/Jobs/ATH/kommandant.yml
+++ b/_Crescent/Roles/Jobs/ATH/kommandant.yml
@@ -75,3 +75,5 @@
     belt: ClothingBeltSheathFilled
     id: KommandantPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponRevolverMateba
+    pocket2: SpeedLoaderMagnum

--- a/_Crescent/Roles/Jobs/ATH/leutnant.yml
+++ b/_Crescent/Roles/Jobs/ATH/leutnant.yml
@@ -67,8 +67,8 @@
   id: LeutnantGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthorityLeutnant
-    back: ClothingBackpackSatchelLeatherFilledDSM
-    shoes: ClothingShoesBootsJack
+    back: ClothingBackpackSatchelLeatherAuthorityFilled
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthorityLeutnant
     outerClothing: ClothingOuterCoatAuthorityLeutnant
     id: LeutnantPDA

--- a/_Crescent/Roles/Jobs/ATH/leutnant.yml
+++ b/_Crescent/Roles/Jobs/ATH/leutnant.yml
@@ -73,5 +73,5 @@
     outerClothing: ClothingOuterCoatAuthorityLeutnant
     id: LeutnantPDA
     ears: ClothingHeadsetAuthority
-    pocket1: WeaponRevolverMateba
-    pocket2: SpeedLoaderMagnum
+    pocket1: WeaponPistolN1984
+    pocket2: MagazineMagnum

--- a/_Crescent/Roles/Jobs/ATH/leutnant.yml
+++ b/_Crescent/Roles/Jobs/ATH/leutnant.yml
@@ -73,3 +73,5 @@
     outerClothing: ClothingOuterCoatAuthorityLeutnant
     id: LeutnantPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponRevolverMateba
+    pocket2: SpeedLoaderMagnum

--- a/_Crescent/Roles/Jobs/ATH/sanitat.yml
+++ b/_Crescent/Roles/Jobs/ATH/sanitat.yml
@@ -66,7 +66,7 @@
   id: SanitatGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthoritySanitat
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthoritySanitat
     belt: ClothingBeltAuthorityDroppouches
     gloves: ClothingHandsGlovesFingerless

--- a/_Crescent/Roles/Jobs/ATH/sanitat.yml
+++ b/_Crescent/Roles/Jobs/ATH/sanitat.yml
@@ -72,3 +72,5 @@
     gloves: ClothingHandsGlovesFingerless
     id: SanitatPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponPistolMk58
+    pocket2: MagazinePistol

--- a/_Crescent/Roles/Jobs/ATH/soldat.yml
+++ b/_Crescent/Roles/Jobs/ATH/soldat.yml
@@ -65,7 +65,7 @@
   id: SoldatGear
   equipment:
     jumpsuit: ClothingUniformJumpsuitAuthoritySoldat
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsCombatFilled
     head: ClothingHeadHatAuthoritySoldat
     belt: ClothingBeltAuthorityPouches
     gloves: ClothingHandsGlovesFingerless

--- a/_Crescent/Roles/Jobs/ATH/soldat.yml
+++ b/_Crescent/Roles/Jobs/ATH/soldat.yml
@@ -71,3 +71,5 @@
     gloves: ClothingHandsGlovesFingerless
     id: SoldatPDA
     ears: ClothingHeadsetAuthority
+    pocket1: WeaponPistolMk58
+    pocket2: MagazinePistol


### PR DESCRIPTION
Adds loadout options to all ATH jobs.
Kommandants and Leutnants get a Mateba and one speedloader.
Kanoneers get a Smartpistol and one smartgun magazine
Sanitats and Soldats get a 9mm Pistol and one pistol magazine
Backpacks are pre-filled with a survival box, flash, zipties and shrapnel grenade.

All weapons are now SHI sourced.